### PR TITLE
tiff2holes can handle monochrome (green-channel) TIFFs

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -87,7 +87,8 @@ class RollImage : public TiffFile, public RollOptions {
 		                 RollImage                    (void);
 		                ~RollImage                    ();
 
-		void	          loadGreenChannel              (int threshold);
+		void	        loadGreenChannel              (int threshold);
+		void	        setMonochrome                 (bool value);
 		void            analyze                       (void);
 		void            analyzeHoles                  (void);
 		void            mergePixelOverlay             (std::fstream& output);
@@ -339,6 +340,7 @@ class RollImage : public TiffFile, public RollOptions {
 		double     m_dustscorebass;
 		double     m_dustscoretreble;
 		double     m_averageHoleWidth;
+		bool       m_isMonochrome;
 
 #ifndef DONOTUSEFFT
 		std::chrono::system_clock::time_point start_time;

--- a/include/TiffFile.h
+++ b/include/TiffFile.h
@@ -37,6 +37,7 @@ class TiffFile : public std::fstream, public TiffHeader {
 		std::string readString                  (ulongint count);
 		ucharint    read1UByte                  (void);
 		void        getImageGreenChannel        (std::vector<std::vector<ucharint> >& image);
+		void        getImageChannel             (std::vector<std::vector<ucharint> >& image);
 		bool        goToPixelIndex              (ulonglongint pindex);
 		bool        goToRowColumnIndex          (ulongint rowindex, ulongint colindex);
 		std::string getFilename                 (void);

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -64,6 +64,7 @@ void RollImage::clear(void) {
 	m_dustscorebass             = -1.0;
 	m_dustscoretreble           = -1.0;
 	m_averageHoleWidth          = -1.0;
+	m_isMonochrome              = false; 
 }
 
 
@@ -113,6 +114,16 @@ string RollImage::my_to_string(int value) {
 	stringstream stream;
 	stream << value;
 	return stream.str();
+}
+
+
+
+//////////////////////////////
+//
+// RollImage::setMonochrome 
+//
+void RollImage::setMonochrome(bool value) {
+	m_isMonochrome = value;
 }
 
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -138,7 +138,11 @@ void RollImage::loadGreenChannel(int threshold) {
 	setThreshold(threshold);
 	ulongint rows = getRows();
 	ulongint cols = getCols();
-	this->getImageGreenChannel(monochrome);
+	if (!m_isMonochrome) {
+		this->getImageGreenChannel(monochrome);
+        } else {
+		this->getImageChannel(monochrome);
+	}
 	pixelType.resize(rows);
 	for (ulongint r=0; r<rows; r++) {
 		pixelType[r].resize(getCols());

--- a/src/TiffFile.cpp
+++ b/src/TiffFile.cpp
@@ -189,6 +189,29 @@ void TiffFile::getImageGreenChannel(vector<vector<ucharint> >& image) {
 
 //////////////////////////////
 //
+// TiffFile::getImageChannel --
+//
+
+void TiffFile::getImageChannel(vector<vector<ucharint> >& image) {
+	//PMB -- works if monochrome because it's always 0
+	this->goToPixelIndex((int)0);
+	ulongint rows = this->getRows();
+	ulongint cols = this->getCols();
+	ucharint pixel;
+	image.resize(rows);
+	for (ulongint r=0; r<rows; r++) {
+		image.at(r).resize(cols);
+		for (ulongint c=0; c<cols; c++) {
+			pixel = this->read1UByte();
+			image.at(r).at(c) = pixel;
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
 // TiffFile::writeSamplesPerPixel -- 1 = monochrome, 3 = color.
 //
 

--- a/src/TiffHeader.cpp
+++ b/src/TiffHeader.cpp
@@ -78,6 +78,7 @@ void TiffHeader::clear(void) {
 	m_64bitQ          = false;
 	m_samplesperpixel = 0;
 
+	m_allowMonochrome = true;
 
 	// clear file offsets:
 	m_samplesperpixel_offset = 0;
@@ -499,7 +500,7 @@ bool TiffHeader::readDirectoryEntry(std::fstream& input) {
 		case 262: // photometric interpretation
 			// Shouldn't be needed, require to be 2: 0,0,0=black 255,255,255=white
 			value = (ulongint)this->readEntryUInteger(input, datatype, count, id);
-			if (value != 2) {
+			if ((value != 2) && (value != 1)) {
 				std::cerr << "Cannot handle photometric interpretation " << value << "." << std::endl;
 				return false;
 			}

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -43,6 +43,7 @@ int main(int argc, char** argv) {
 	options.define("5|65|65-note|65-hole=b", "Assume 65-note roll");
 	options.define("8|88|88-note|88-hole=b", "Assume 88-note roll");
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");
+	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
@@ -78,6 +79,7 @@ int main(int argc, char** argv) {
 
 	roll.setDebugOn();
 	roll.setWarningOn();
+	roll.setMonochrome(options.getBoolean("monochrome"));
 	roll.loadGreenChannel(threshold);
 	roll.analyze();
 	roll.printRollImageProperties();


### PR DESCRIPTION
These edits should allow `tiff2holes` to process monochrome (green-channel) TIFF roll images when given the `-m` command-line switch (and process RGB TIFFs by default when not given the switch). Green-channel TIFFs of the rolls can be downloaded directly from the SDR, e.g., https://stacks.stanford.edu/file/zb497jz4405/zb497jz4405_0001_gr.tif

Makes Issue #5 irrelevant.