### PR TITLE
Store tracker hole to MIDI key mapping, use in analysis report

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -207,6 +207,8 @@ class RollImage : public TiffFile, public RollOptions {
 		// (in image, not roll).  Zero means no mapping (not allowed to reference
 		// position 0 in trackerArray).
 		std::vector<int> midiToTrackMapping;
+		// trackToMidiMapping -- the inverse of midiToTrackMapping
+		std::vector<int> trackToMidiMapping;
 
 		// trackMeaning -- the function of the hole, mostly for expression
 		// and rewind hole.

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -506,6 +506,7 @@ void RollImage::assignMidiKeyNumbersToHoles(void) {
 			continue;
 		}
 		midiKey[i] = trackerArray[i][0]->midikey;
+		firstHole[i] = trackerArray[i][0]->origin.first;
 
 		if (firstHole[i] > maxorigin) {
 			maxorigin = firstHole[i];
@@ -4065,7 +4066,7 @@ void RollImage::generateNoteMidiFileHex(ostream& output) {
 
 //////////////////////////////
 //
-// RollImage::generateHoldMidiFileHex -- Generate MIDI file where holes are not grouped into notes.
+// RollImage::generateHoleMidiFileHex -- Generate MIDI file where holes are not grouped into notes.
 //   I.e., no brige merging.
 //
 
@@ -4881,8 +4882,6 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@ \t\t\t   HPIXCOR_TRAIL:\tHorizontal pixel correction of the hole's trailing edge.\n";
 	out << "@@\n";
 	out << "\n";
-
-	assignMidiKeyNumbersToHoles();
 
 	out << "@@BEGIN: HOLES\n\n";
 	for (ulongint i=0; i<holes.size(); i++) {

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -472,8 +472,6 @@ void RollImage::calculateHoleDescriptors(void) {
 //
 
 void RollImage::assignMidiKeyNumbersToHoles(void) {
-	// Initialize tracker hole -> midi number mapping
-
 	for (int i=0; i<(int)midiToTrackMapping.size(); i++) {
 		int track = midiToTrackMapping[i];
 		if (track <= 0) {
@@ -780,7 +778,8 @@ void RollImage::analyzeMidiKeyMapping(void) {
 		}
 	}
 
-	//PMB temporary fix for Welte red rolls
+	// This is to keep the MIDI numbers assigned to holes from being misaligned
+	// by 1, but a refactor is needed to prevent cases like this from happening
 	if ((m_rollType == "welte-red") && (position.size() <= 108)) {
 		leftmostIndex += 1;
 		std::cerr << "shifting leftmostIndex for red Welte roll to " << leftmostIndex << std::endl;
@@ -5126,11 +5125,7 @@ std::string RollImage::getDruid(std::string input) {
 	if (input.empty()) {
 		input = getFilename();
 	}
-	auto loc = input.find_last_of('/');
-	if (loc != string::npos) {
-		input = input.substr(loc+1, input.size());
-	}
-	loc = input.find_last_of("\\/");
+	auto loc = input.find_last_of("\\/");
 	if (loc != string::npos) {
 		input = input.substr(loc+1, input.size());
 	}

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -5126,7 +5126,15 @@ std::string RollImage::getDruid(std::string input) {
 	if (input.empty()) {
 		input = getFilename();
 	}
-	auto loc = input.find('_');
+	auto loc = input.find_last_of('/');
+	if (loc != string::npos) {
+		input = input.substr(loc+1, input.size());
+	}
+	loc = input.find_last_of("\\/");
+	if (loc != string::npos) {
+		input = input.substr(loc+1, input.size());
+	}
+	loc = input.find('_');
 	if (loc != string::npos) {
 		input = input.substr(0, loc);
 	}


### PR DESCRIPTION
The main change in this PR is the addition of a map (vector) from tracker hole IDs to MIDI key mappings, which is just the inverse of the MIDI key -> tracker map that already existed. Not the most elegant solution, but it seemed the last likely to cause unexpected harm.

The new map is used to set the `MID_KEY` value to a non-`-1` value for each hole in the hole report data, which can then be used on the front-end for things like hole highlighting.

Also included is a temporary band-aid fix for the problem that sometimes the tracker assignments for holes in Welte red rolls are misaligned by one hole, resulting in bad MIDI files. This fix works for the 5 Welte red rolls in the test set, but further work will be needed to ensure that the correct mappings are made for all of the rolls in the collection.

Other changes include minor code cleanup and a refinement to the `getDruid()` function.