### PR TITLE
Use first detected music hole when generating MIDI files

### DIFF
--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4365,7 +4365,10 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 		midifile.addController(m_treble_track,     tick, m_treble_ch,    10, 96); // treble notes pan rightish
 	}
 
-	ulongint mintime = holes[0]->origin.first;
+	// PMB Note that this can be different from hole MIDI. Assigning tick 0 to (likely spurious)
+	// non-music holes can lead to a timing gap at the start of the MIDI file, so the first tick
+	// is moved up to the first music hole.
+	ulongint mintime = firstMusicRow;
 	ulongint maxtime = 0;
 
 	int track;
@@ -4409,8 +4412,22 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 			velocity = velocitynormal;
 		}
 
-		midifile.addNoteOn(track, hi->origin.first - mintime, channel, hi->midikey, velocity);
-		midifile.addNoteOff(track, hi->offtime - mintime, channel, hi->midikey);
+		// PMB Set tick of (likly spurious) holes before first music hole to 0; otherwise their
+		// tick values can be negative, which corrupts the output.
+		int ontick = hi->origin.first - mintime;
+		int offtick = hi->offtime - mintime;
+
+		if (ontick < 0) {
+			cerr << "ERROR ON TIME LESS THAN ZERO: " << ontick << " FOR KEY " << hi->midikey << endl;
+			ontick = 0;
+		}
+		if (offtick < 0) {
+			cerr << "ERROR OFF TIME LESS THAN ZERO: " << offtick << " FOR KEY " << hi->midikey << endl;
+			offtick = 0;
+		}
+
+		midifile.addNoteOn(track, ontick, channel, hi->midikey, velocity);
+		midifile.addNoteOff(track, offtick, channel, hi->midikey);
 
 		if (hi->offtime <= 0) {
 			cerr << "ERROR OFFTIME IS ZERO: " << hi->offtime << endl;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4412,7 +4412,7 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 			velocity = velocitynormal;
 		}
 
-		// PMB Set tick of (likly spurious) holes before first music hole to 0; otherwise their
+		// PMB Set tick of (likely spurious) holes before the first music hole to 0; otherwise their
 		// tick values can be negative, which corrupts the output.
 		int ontick = hi->origin.first - mintime;
 		int offtick = hi->offtime - mintime;


### PR DESCRIPTION
As originally written, the code to generate the raw and note MIDI files uses the position of the first overall detected hole, rather than the first music-related hole, as the location of MIDI tick 0, reported in the roll metadata as the `FIRST_HOLE` value. As in the case of roll yj598pj2879, if a spurious or inconsequential non-music hole is detected and used in this manner, the result is that the expected alignment between MIDI tick values and pixels on the roll does not hold; it also adds excessive silence to the beginning of playback and makes drawing dynamic overlays onto the holes during playback difficult.

A considerable amount of code exists to detect the first actual music-related hole. The suggested change uses this position when generating the note MIDI output, setting the tick values of any (likely spurious) holes that appear prior to it to 0. The location of the first hole overall is still used when generating the raw (non-grouped holes) MIDI output, however, as this is meant to be more of a verbatim representation of the hole detection output in MIDI format.

Closes issue [#2](https://github.com/sul-cidr/roll-image-parser/issues/2).