### PR TITLE
Simplify MIDI_KEY assignment by reordering pre-existing functions

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -207,8 +207,6 @@ class RollImage : public TiffFile, public RollOptions {
 		// (in image, not roll).  Zero means no mapping (not allowed to reference
 		// position 0 in trackerArray).
 		std::vector<int> midiToTrackMapping;
-		// trackToMidiMapping -- the inverse of midiToTrackMapping
-		std::vector<int> trackToMidiMapping;
 
 		// trackMeaning -- the function of the hole, mostly for expression
 		// and rewind hole.

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4127,8 +4127,6 @@ void RollImage::generateHoleMidifile(MidiFile& midifile) {
 	insertRollImageProperties(midifile);
 	midifile.addText(0, 0, "@MIDIFILE_TYPE:\t\thole");
 
-	assignMidiKeyNumbersToHoles();
-
 	setMidiFileTempo(midifile);
 
 	// Tracks are organized by real notes first, then expression tracks.
@@ -4280,8 +4278,6 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 
 	insertRollImageProperties(midifile);
 	midifile.addText(0, 0, "@MIDIFILE_TYPE:\t\tnote");
-
-	assignMidiKeyNumbersToHoles();
 
 	setMidiFileTempo(midifile);
 
@@ -4876,6 +4872,8 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@ \t\t\t   HPIXCOR_TRAIL:\tHorizontal pixel correction of the hole's trailing edge.\n";
 	out << "@@\n";
 	out << "\n";
+
+	assignMidiKeyNumbersToHoles();
 
 	out << "@@BEGIN: HOLES\n\n";
 	for (ulongint i=0; i<holes.size(); i++) {

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -789,16 +789,11 @@ void RollImage::analyzeMidiKeyMapping(void) {
 	midiToTrackMapping.resize(128);
 	std::fill(midiToTrackMapping.begin(), midiToTrackMapping.end(), 0);
 
-	// Initialize the track-to-MIDI mapping:
-	trackToMidiMapping.resize(128);
-	std::fill(trackToMidiMapping.begin(), trackToMidiMapping.end(), 0);
-
 	// Assign MIDI key positions to the mapping, starting with
 	// the first position.
 	int count = m_treble_midi - m_bass_midi + 1;
 	for (int i=0; i<count; i++) {
 		midiToTrackMapping.at(i+m_bass_midi) = i+leftmostIndex;
-		trackToMidiMapping.at(i+leftmostIndex) = i+m_bass_midi;
 	}
 
 	// int trackerholes = getMeasuredTrackerHoleCount();
@@ -4885,7 +4880,6 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@BEGIN: HOLES\n\n";
 	for (ulongint i=0; i<holes.size(); i++) {
 		if (holes.at(i)->isMusicHole()) {
-			holes.at(i)->midikey = trackToMidiMapping[holes.at(i)->track];
 			holes.at(i)->printAton(out);
 			out << std::endl;
 		}


### PR DESCRIPTION
This walks back the changes made in PR [#7](https://github.com/sul-cidr/roll-image-parser/pull/7) -- specifically, building a tracker-position-to-MIDI-number mapping and using this to assign the `MIDI_KEY` value to holes in the report from `tiff2holes` -- in favor of a simpler approach. Code to assign the `MIDI_KEY`values already existed in the aptly named `assignMidiKeyNumbersToHoles()` but it wasn't being run before the hole report was generated. Moving the invocation of this function prior to the hole report output solves the problem directly.