### PR TITLE
Add parsing params and cmd line options to parse Welte green and licensee roll images

### DIFF
--- a/include/RollOptions.h
+++ b/include/RollOptions.h
@@ -51,6 +51,7 @@ class RollOptions {
 		std::string getRollType               (void);
 		void     setRollTypeRedWelte          (void);
 		void     setRollTypeGreenWelte        (void);
+		void     setRollTypeLicenseeWelte     (void);
 		void     setRollType65Note            (void);
 		void     setRollType88Note            (void);
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4253,10 +4253,18 @@ void RollImage::setMidiFileTempo(MidiFile& midifile) {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
 		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute).
 		midifile.setTPQ(591);
+	} else if (m_rollType == "welte-green") {
+		// Peter Phillips's dissertation describes the speed for green Welte
+		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =
+		// tempo of 70.0532 (* 6 = 420)
+		midifile.setTPQ(420);
 	} else if (m_rollType == "88-note") {
 		midifile.setTPQ(6 * 60); 
 	} else {
 		// set to a neutral guess tempo of 80 for now if unknown, this can be adjusted later.
+		// Note that this is equivalent to the median speed of "eight feet per
+		// minute" that Peter Phillips mentions for the De Luxe Welte Licensee
+		// rolls (p. 126): 8ft/min = 2.4384m/min = tempo of 80.0608
 		midifile.setTPQ(6 * 80); 
 	}
 }

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4252,12 +4252,12 @@ void RollImage::setMidiFileTempo(MidiFile& midifile) {
 	if (m_rollType == "welte-red") {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
 		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute).
-		midifile.setTPQ(591);
+		midifile.setTPQ(6 * 98.5);
 	} else if (m_rollType == "welte-green") {
 		// Peter Phillips's dissertation describes the speed for green Welte
 		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =
 		// tempo of 70.0532 (* 6 = 420)
-		midifile.setTPQ(420);
+		midifile.setTPQ(6 * 70);
 	} else if (m_rollType == "88-note") {
 		midifile.setTPQ(6 * 60); 
 	} else {

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -343,7 +343,7 @@ void RollOptions::setRollTypeRedWelte(void) {
 
 //////////////////////////////
 //
-// RollOptions::setRollTypeGreenWelte -- Apply settings suitable for Red Welte (T-98) piano rolls.
+// RollOptions::setRollTypeGreenWelte -- Apply settings suitable for Green Welte (T-98) piano rolls.
 //
 // Peter Phillips dissertation: https://ses.library.usyd.edu.au/bitstream/2123/16939/1/Piano%20Rolls.pdf
 //
@@ -355,14 +355,14 @@ void RollOptions::setRollTypeRedWelte(void) {
 //       3:  Sustain pedal                   MIDI Key 18
 //       4:  Bass Crescendo                  MIDI Key 19
 //       5:  Bass Sforzando forte            MIDI Key 20
-//   Then 88 notes from C0 to C8 (MIDI notes 21 to 108) (but actually only 80 used)
+//   Then 88 notes from A0 to C8 (MIDI notes 21 to 108)
 //       6: A0                               MIDI Key 21
 //       ...
 //       51:  F#4                            MIDI Key 66
 //    Treble register:
 //       52:  G4                             MIDI Key 67
 //       ...
-//       93:  G7                             MIDI Key 108
+//       93:  C8                             MIDI Key 108
 //   5 expression holes on the treble side:
 //       94:  -5:  Treble Sforzando forte    MIDI Key 109
 //       95:  -4:  Treble Crescendo          MIDI Key 110
@@ -372,9 +372,6 @@ void RollOptions::setRollTypeRedWelte(void) {
 //
 
 void RollOptions::setRollTypeGreenWelte(void) {
-	cerr << "GREEN ROLL NOT IMPLEMENT YET" << endl;
-	exit(1);
-
 	m_rollType = "welte-green";
 	m_minTrackerSpacingToPaperEdge = 1.6; // check
 	m_rewindHole = 1;  // 1st hole from left (bass), but only if "long"
@@ -389,7 +386,7 @@ void RollOptions::setRollTypeGreenWelte(void) {
 	m_bassNotesTrackStartNumberLeft = 6;
 	m_bassNotesTrackStartMidi = 21;
 
-	m_trebleNotesTrackStartNumberLeft = 54;
+	m_trebleNotesTrackStartNumberLeft = 52;
 	m_trebleNotesTrackStartMidi = 67;
 
 	m_trebleExpressionTrackStartNumberLeft = 94;

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -263,7 +263,7 @@ void RollOptions::setHoleShiftCutoff(double value) {
 //   "" = unknown/unspecified
 //   "welte-red"      = Welte Mignon T-100 red roll
 //   "welte-green"    = Welte Mignon T-98 green roll
-//   "welte-licensee" = Welte Mignon (Deluxe) Licensee
+//   "welte-licensee" = Welte Mignon (De Luxe) Licensee
 //   "ampico"         = AMPICO roll (variation not specified)
 //   "ampico-a"       = AMPICO roll, earlier model
 //   "ampico-b"       = AMPICO roll, later model
@@ -394,6 +394,68 @@ void RollOptions::setRollTypeGreenWelte(void) {
 
 	m_trebleExpressionTrackStartNumberLeft = 94;
 	m_trebleExpressionTrackStartMidi = 109;
+
+	hasExpressionMidiFileSetup();
+}
+
+
+
+//////////////////////////////
+//
+// RollOptions::setRollTypeLicenseeWelte -- Apply settings suitable for Welte Licensee (US De Luxe) piano rolls.
+//
+// Welte Licensee tracker holes:
+//
+//   8 expression holes on bass side:
+//       1:  Bass Mezzoforte off             MIDI Key 16
+//       2:  Bass Mezzoforte on              MIDI Key 17
+//       3:  Bass Crescendo off              MIDI Key 18
+//       4:  Bass Crescendo on               MIDI Key 19
+//       5:  Bass Sforzando off              MIDI Key 20
+//       6:  Bass Sforzando on               MIDI Key 21
+//       7:  Soft pedal on                   MIDI Key 22
+//       8:  Soft pedal off                  MIDI Key 23
+//   Then 80 notes from C1 to G7 (MIDI notes 24 to 103)
+//       9:  C1                              MIDI Key 24
+//       ...
+//       51:  F#4                            MIDI Key 66
+//    Treble register:
+//       52:  G4                             MIDI Key 67
+//       ...
+//       88:  G7                             MIDI Key 103
+//   10 expression holes on the treble side:
+//       89: -10:  Rewind                    MIDI Key 104
+//       90:  -9:  Blank                    [MIDI Key 105]
+//       91:  -8:  Sustain pedal on          MIDI Key 106
+//       92:  -7:  Sustain pedal off         MIDI Key 107
+//       93:  -6:  Treble Sforzando on       MIDI Key 108
+//       94:  -5:  Treble Sforzando off      MIDI Key 109
+//       95:  -4:  Treble Crescendo on       MIDI Key 110
+//       96:  -3:  Treble Crescendo off      MIDI Key 111
+//       97:  -2:  Treble Mezzoforte on      MIDI Key 112
+//       98:  -1:  Treble Mezzoforte off     MIDI Key 113
+//		 
+
+void RollOptions::setRollTypeLicenseeWelte(void) {
+	m_rollType = "welte-licensee";
+	m_minTrackerSpacingToPaperEdge = 1.6; // check
+	m_rewindHole = 89;
+	m_rewindHoleMidi = 104;
+	m_trackerHoles = 98;
+
+	m_bass_midi = 16;   // first MIDI Note on bass side of paper
+	m_treble_midi = 113; // first MIDI Note on treble side of paper
+
+	m_bassExpressionTrackStartNumberLeft = 1;
+	m_bassExpressionTrackStartMidi = 16;
+	m_bassNotesTrackStartNumberLeft = 9;
+	m_bassNotesTrackStartMidi = 24;
+
+	m_trebleNotesTrackStartNumberLeft = 52;
+	m_trebleNotesTrackStartMidi = 67;
+
+	m_trebleExpressionTrackStartNumberLeft = 89;
+	m_trebleExpressionTrackStartMidi = 104;
 
 	hasExpressionMidiFileSetup();
 }

--- a/tools/markholes.cpp
+++ b/tools/markholes.cpp
@@ -15,7 +15,7 @@
 //                    bin/markholes input.tiff copy.tiff > analysis.txt
 // Options:
 //     -r         Assume a Red Welte-Mignon piano roll (T-100).
-//     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
+//     -g         Assume a Green Welte-Mignon piano roll (T-98).
 //     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll.
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
@@ -38,7 +38,7 @@ using namespace rip;
 int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
-	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
+	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll");
 	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");

--- a/tools/markholes.cpp
+++ b/tools/markholes.cpp
@@ -16,7 +16,7 @@
 // Options:
 //     -r         Assume a Red Welte-Mignon piano roll (T-100).
 //     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
-//     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll, but option not yet active.
+//     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll.
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
 //     -d         Assume a Duo-Art piano roll, but option not yet active.
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
 	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
-	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll (option not active yet)");
+	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
 	options.define("d|duo-art=b", "Assume Aeolean Duo-Art piano roll (option not active yet)");
@@ -65,6 +65,8 @@ int main(int argc, char** argv) {
 		roll.setRollTypeRedWelte();
 	} else if (options.getBoolean("green-welte")) {
 		roll.setRollTypeGreenWelte();
+	} else if (options.getBoolean("licensee-welte")) {
+		roll.setRollTypeLicenseeWelte();
 	} else if (options.getBoolean("65-note")) {
 		roll.setRollType65Note();
 	} else if (options.getBoolean("88-note")) {
@@ -73,6 +75,7 @@ int main(int argc, char** argv) {
 		cerr << "A Roll type is required:" << endl;
 		cerr << "   -r   == for red Welte rolls"   << endl;
 		cerr << "   -g   == for green Welte rolls" << endl;
+		cerr << "   -l   == for Licensee Welte rolls" << endl;
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -12,7 +12,7 @@
 //                markup of the copy of the input image.
 // Options:
 //     -r         Assume a Red Welte-Mignon piano roll (T-100).
-//     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
+//     -g         Assume a Green Welte-Mignon piano roll (T-98).
 //     -l         Assume a Welte-Mignon (De Luxe) Licensee piano roll
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
@@ -35,7 +35,7 @@ using namespace rip;
 int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
-	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
+	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll");
 	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
-		cerr << "Usage: tiff2holes [-rl58tm] file.tiff > analysis.txt" << endl;
+		cerr << "Usage: tiff2holes [-rgl58tm] file.tiff > analysis.txt" << endl;
 		cerr << "file.tiff must be a 24-bit color image, uncompressed" << endl;
 		cerr << "unless -m is supplied; then file.tiff must be a monochrome" << endl;
 		cerr << "(8-bit, single-channel) image, uncompressed" << endl;

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -11,9 +11,9 @@
 //                program as markholes.cpp, but this one does not do analytic
 //                markup of the copy of the input image.
 // Options:
-//     -r         Assume a Red Welte-Mignon piano roll (T-100). (currently hard-wired on until more roll types implemented)
+//     -r         Assume a Red Welte-Mignon piano roll (T-100).
 //     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
-//     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll, but option not yet active.
+//     -l         Assume a Welte-Mignon (De Luxe) Licensee piano roll
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
 //     -d         Assume a Duo-Art piano roll, but option not yet active.
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
 	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
-	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll (option not active yet)");
+	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
 	options.define("d|duo-art=b", "Assume Aeolean Duo-Art piano roll (option not active yet)");
@@ -47,8 +47,10 @@ int main(int argc, char** argv) {
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
-		cerr << "Usage: tiff2holes [-rt] file.tiff > analysis.txt" << endl;
+		cerr << "Usage: tiff2holes [-rl58tm] file.tiff > analysis.txt" << endl;
 		cerr << "file.tiff must be a 24-bit color image, uncompressed" << endl;
+		cerr << "unless -m is supplied; then file.tiff must be a monochrome" << endl;
+		cerr << "(8-bit, single-channel) image, uncompressed" << endl;
 		exit(1);
 	}
 
@@ -62,6 +64,8 @@ int main(int argc, char** argv) {
 		roll.setRollTypeRedWelte();
 	} else if (options.getBoolean("green-welte")) {
 		roll.setRollTypeGreenWelte();
+	} else if (options.getBoolean("licensee-welte")) {
+		roll.setRollTypeLicenseeWelte();
 	} else if (options.getBoolean("65-note")) {
 		roll.setRollType65Note();
 	} else if (options.getBoolean("88-note")) {
@@ -70,6 +74,7 @@ int main(int argc, char** argv) {
 		cerr << "A Roll type is required:" << endl;
 		cerr << "   -r   == for red Welte rolls"   << endl;
 		cerr << "   -g   == for green Welte rolls" << endl;
+		cerr << "   -l   == for Licensee Welte rolls" << endl;
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);


### PR DESCRIPTION
Theoretically, all that's needed to support a new roll type is to specify the expected distance of the first hole from the edge of the paper, the expected number of tracker bar holes, and the MIDI ranges to which the tracker bar holes correspond.

The parameters for the Welte green rolls were already in place and mostly correct. The Licensee parameters are essentially a reconfiguration of the Green setup -- they have the same number of tracker holes (98), but the Licensee sacrifices some note coverage on the low bass and high treble ranges of the keyboard to support a somewhat more streamlined version of the "lock-and-cancel" expression system used for the Red (T-100) rolls. Green (T-98) rolls don't do lock-and-cancel; each expression is in effect for the duration of the hole grouping, which frees up holes for full 88-note keyboard coverage.