### PR TITLE
Exclude notes from note MIDI with start or stop times before first music hole

### DIFF
--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4435,12 +4435,6 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 		midifile.addNoteOn(track, ontick, channel, hi->midikey, velocity);
 		midifile.addNoteOff(track, offtick, channel, hi->midikey);
 
-		if (hi->offtime <= 0) {
-			cerr << "ERROR OFFTIME IS ZERO: " << hi->offtime << endl;
-		}
-		if (hi->offtime < hi->origin.first) {
-			cerr << "ERROR OFF TIME IS BEFORE ON TIME " << hi->origin.first << " VERSUS " << hi->offtime << " FOR KEY " << hi->midikey << endl;
-		}
 		if (hi->offtime > maxtime) {
 			maxtime = hi->offtime;
 		}

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4423,18 +4423,13 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 			velocity = velocitynormal;
 		}
 
-		// PMB Set tick of (likely spurious) holes before the first music hole to 0; otherwise their
-		// tick values can be negative, which corrupts the output.
+		// Skip likely spurious holes appearing before the first music hole.
 		int ontick = hi->origin.first - mintime;
 		int offtick = hi->offtime - mintime;
 
-		if (ontick < 0) {
-			cerr << "ERROR ON TIME LESS THAN ZERO: " << ontick << " FOR KEY " << hi->midikey << endl;
-			ontick = 0;
-		}
-		if (offtick < 0) {
-			cerr << "ERROR OFF TIME LESS THAN ZERO: " << offtick << " FOR KEY " << hi->midikey << endl;
-			offtick = 0;
+		if ((ontick < 0) || (offtick < 0)) {
+			cerr << "NOTE ON TICK OR OFF TICK LESS THAN ZERO: " << ontick << " -> " << offtick << " FOR KEY " << hi->midikey << ", SKIPPING" << endl;
+			continue;
 		}
 
 		midifile.addNoteOn(track, ontick, channel, hi->midikey, velocity);


### PR DESCRIPTION
The previous approach was to set the start and stop ticks of these "notes" to 0 (equal to the first music hole), but this is kind of an abuse of the MIDI format, and also there seems to be no good way to ensure that a note defined by the following MIDI messages:
`NOTE ON: TICK 0`
`NOTE OFF: TICK 0`
isn't ordered in playback as
`NOTE OFF: TICK 0`
`NOTE ON: TICK 0`
which inverts the ON/OFF values for all subsequent appearances of the note, and really messes up playback.

Furthermore, the likely spurious notes are still represented in the raw MIDI file, which seems intended to represent the parsed roll, warts and all, whereas the note MIDI file is meant to be processed for playback, and so it seems fitting to remove from it the notes that won't be played at all.