### PR TITLE
Disregard candidate first music hole if it's really far above the rest

### DIFF
--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -3253,6 +3253,7 @@ void RollImage::recalculateFirstMusicHole(void) {
 	ulongint minrow = getRows() - 1;
 	std::vector<std::vector<HoleInfo*> >& ta = trackerArray;
 	ulongint row;
+	ulongint nextMusicRow = minrow;
 	for (ulongint i=0; i<ta.size(); i++) {
 		for (ulongint j=0; j<ta[i].size(); j++) {
 			if (!ta[i][j]->isMusicHole()) {
@@ -3261,9 +3262,19 @@ void RollImage::recalculateFirstMusicHole(void) {
 			row = ta[i][j]->origin.first;
 			if (row < minrow) {
 				minrow = row;
+			} else if (row < nextMusicRow) {
+				nextMusicRow = row;
 			}
 		}
 	}
+
+	// Use a conservative distance (2.8 ft) so that only punctures and obvious
+	// outliers appearing well above the rest of the roll are disregarded.
+	if ((nextMusicRow > minrow) && ((nextMusicRow - minrow) > 10000)) {
+		cerr << "FIRST MUSIC HOLE MUCH EARLIER THAN NEXT: " << minrow << " -> " << nextMusicRow << ", SKIPPING" << endl;
+		minrow = nextMusicRow;
+	}
+
 	if (minrow > firstMusicRow) {
 		firstMusicRow = minrow;
 		markPosteriorLeader();


### PR DESCRIPTION
Testing has shown this approach to be effective at disqualifying questionable holes that appear well above the rest of the roll and are highly likely to be tears or punctures. Possibly a smaller threshold and/or a more sophisticated clustering/outlier detection method would catch a few more, but it's not obvious that this would provide a significant benefit vs the risk of disregarding legitimate holes.