### PR TITLE
Provide option to ignore estimated rewind hole for trackerbar->MIDI mapping

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -89,6 +89,7 @@ class RollImage : public TiffFile, public RollOptions {
 
 		void	        loadGreenChannel              (int threshold);
 		void	        setMonochrome                 (bool value);
+		void            setRewindCorrection           (bool value);
 		void            analyze                       (void);
 		void            analyzeHoles                  (void);
 		void            mergePixelOverlay             (std::fstream& output);
@@ -341,6 +342,7 @@ class RollImage : public TiffFile, public RollOptions {
 		double     m_dustscoretreble;
 		double     m_averageHoleWidth;
 		bool       m_isMonochrome;
+		bool       m_useRewindHoleCorrection;
 
 #ifndef DONOTUSEFFT
 		std::chrono::system_clock::time_point start_time;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -64,7 +64,8 @@ void RollImage::clear(void) {
 	m_dustscorebass             = -1.0;
 	m_dustscoretreble           = -1.0;
 	m_averageHoleWidth          = -1.0;
-	m_isMonochrome              = false; 
+	m_isMonochrome              = false;
+	m_useRewindHoleCorrection   = false;
 }
 
 
@@ -124,6 +125,16 @@ string RollImage::my_to_string(int value) {
 //
 void RollImage::setMonochrome(bool value) {
 	m_isMonochrome = value;
+}
+
+
+
+//////////////////////////////
+//
+// RollImage::setRewindCorrection
+//
+void RollImage::setRewindCorrection(bool value) {
+	m_useRewindHoleCorrection = value;
 }
 
 
@@ -491,8 +502,9 @@ void RollImage::assignMidiKeyNumbersToHoles(void) {
 	}
 
 	int rewindholemidi = getRewindHoleMidi();
-	if (!rewindholemidi) {
-		// don't know what type of piano roll or there is no rewind hole, so do
+	if (!rewindholemidi || !m_useRewindHoleCorrection) {
+		// don't know what type of piano roll or there is no rewind hole, or
+		// cmd line specifies not to trust the rewind hole location, so do
 		// not try to make a correction for the expected rewind hole location.
 		return;
 	}

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -65,7 +65,7 @@ void RollImage::clear(void) {
 	m_dustscoretreble           = -1.0;
 	m_averageHoleWidth          = -1.0;
 	m_isMonochrome              = false;
-	m_useRewindHoleCorrection   = false;
+	m_useRewindHoleCorrection   = true;
 }
 
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -576,18 +576,34 @@ void RollImage::assignMidiKeyNumbersToHoles(void) {
 		return;
 	}
 
+	// this is the difference between the MIDI number currently assigned to the
+	// detected rewind hole's tracker column and the MIDI number that the
+	// rewind hole's tracker column should have for this roll type,
+	// assuming that the detected rewind hole truly is the rewind hole
 	int shifting = midiKey[bestFitIndex] - rewindholemidi;
 	cerr << "SHIFTING HOLE ASSIGNMENTS BY " << shifting << " FOR REWIND HOLE ALIGNMENT" << endl;
 
 	for (int i=0; i<(int)trackerArray.size(); i++) {
 		for (int j=0; j<(int)trackerArray[i].size(); j++) {
+			// adjust the MIDI number of every hole in every column by the
+			// discrepancy between the observed and expected MIDI number of the
+			// rewind hole. Holes in tracker columns with midikey < 0 have
+			// already been marked as invalid and won't be affected.
 			if (trackerArray[i][j]->midikey >= 0) {
-				trackerArray[i][j]->midikey += shifting;
+				trackerArray[i][j]->midikey -= shifting;
 			}
+			// each hole's tracker column number is adjusted in the opposite
+			// direction as the MIDI number, to keep it in sync with the
+			// midiToTrackMapping (see below)
 			trackerArray[i][j]->track += shifting;
 		}
 	}
 
+	// adjust the tracker column mapping for each MIDI number by the observed
+	// discrepancy between the current and expected MIDI number of the rewind
+	// hole. This keeps midiToTrackMapping in sync with the adjusted MIDI
+	// number mappings for the holes (above), and is made in the opposite
+	// direction for this reason.
 	for (int i=0; i<(int)midiToTrackMapping.size(); i++) {
 		if (midiToTrackMapping[i] > 0) {
 			midiToTrackMapping[i] += shifting;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -564,7 +564,7 @@ void RollImage::assignMidiKeyNumbersToHoles(void) {
 		return;
 	}
 
-	int shifting = rewindholemidi - midiKey[bestFitIndex];
+	int shifting = midiKey[bestFitIndex] - rewindholemidi;
 	cerr << "SHIFTING HOLE ASSIGNMENTS BY " << shifting << " FOR REWIND HOLE ALIGNMENT" << endl;
 
 	for (int i=0; i<(int)trackerArray.size(); i++) {

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
 	options.define("8|88|88-note|88-hole=b", "Assume 88-note roll");
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");
 	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
+	options.define("s|disregard-rewind-hole=b", "Skip rewind hole correction for tracker->MIDI mapping");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
@@ -78,6 +79,10 @@ int main(int argc, char** argv) {
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);
+	}
+
+    if (options.getBoolean("disregard-rewind-hole")) {
+		roll.setRewindCorrection(false);
 	}
 
 	int threshold = options.getInteger("threshold");


### PR DESCRIPTION
Needs to be rebased against master after PR #14 is merged.