### PR TITLE
Record the end pixel of the rewind hole in the parser report (if found)

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -89,6 +89,7 @@ class RollImage : public TiffFile, public RollOptions {
 
 		void	        loadGreenChannel              (int threshold);
 		void	        setMonochrome                 (bool value);
+		void            setRewindCorrection           (bool value);
 		void            analyze                       (void);
 		void            analyzeHoles                  (void);
 		void            mergePixelOverlay             (std::fstream& output);
@@ -341,6 +342,7 @@ class RollImage : public TiffFile, public RollOptions {
 		double     m_dustscoretreble;
 		double     m_averageHoleWidth;
 		bool       m_isMonochrome;
+		bool       m_useRewindHoleCorrection;
 
 #ifndef DONOTUSEFFT
 		std::chrono::system_clock::time_point start_time;

--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -106,6 +106,7 @@ class RollImage : public TiffFile, public RollOptions {
 		ulongint        getPreleaderIndex             (void);
 		ulongint        getFirstMusicHoleStart        (void);
 		ulongint        getLastMusicHoleEnd           (void);
+		ulongint        getRewindHoleEnd              (void);
 		int             getSoftMarginLeftWidth        (ulongint rowindex);
 		int             getSoftMarginRightWidth       (ulongint rowindex);
 		int             getSoftMarginLeftWidthMax     (void);
@@ -335,6 +336,7 @@ class RollImage : public TiffFile, public RollOptions {
 		ulongint   leaderIndex;
 		ulongint   firstMusicRow;
 		ulongint   lastMusicRow;
+		ulongint   rewindHoleEnd;
 		double     m_lastHolePosition;
 		double     m_firstHolePosition;
 		double     m_dustscore;

--- a/include/RollOptions.h
+++ b/include/RollOptions.h
@@ -51,6 +51,7 @@ class RollOptions {
 		std::string getRollType               (void);
 		void     setRollTypeRedWelte          (void);
 		void     setRollTypeGreenWelte        (void);
+		void     setRollTypeLicenseeWelte     (void);
 		void     setRollType65Note            (void);
 		void     setRollType88Note            (void);
 

--- a/include/RollOptions.h
+++ b/include/RollOptions.h
@@ -62,6 +62,10 @@ class RollOptions {
 		int      getExpectedTrackerHoleCount  (void);
 		void     setThreshold                 (int value);
 		int      getThreshold                 (void);
+		double   getPixelsPerInch             (void);
+
+		double   getRollAcceleration          (void);
+		void     setRollAcceleration          (double value);
 
 	protected: // (maybe make private, but will have to create accessor functions)
 		// m_minTrackerSpacingToPaperEdge: minimum distance from paper
@@ -72,6 +76,9 @@ class RollOptions {
 		// m_maxHoleWidth: maximum width of music holes in units of tracker
 		// bar spacings.
 		double	m_maxHoleWidth;
+
+		// m_pixelsPerInch: image resolution, ideally full-resolution/raw
+		double   m_pixelsPerInch;
 
 		// m_aspectRatioThreshold: maximum w/h ratio
 		double   m_aspectRatioThreshold;
@@ -151,17 +158,12 @@ class RollOptions {
 		// m_threshold: brightness threshold (0-255) for separation of paper and non-paper.
 		int m_threshold        = 249;
 
-		// m_tempo_additive_acceleration_per_foot: the roll acceleration emulation.  This
-		// is the amount added to the tempo BPM for after each foot of the roll.  Value of
-		// 0.22 is from Wayne Stankhe.  The tempo is always starting at "60" and the value
-		// is relative, so the 2nd foot will be at tempo 60.22.  This emulation will need
-		// refinement in the future.  Note the the acceleration tempo is different from the 
-		// roll tempo.  The roll tempo is stored in the MIDI file ticks-per-quarter-note value,
-		// which represents the lines of the image per second (i.e., without acceleration emulation).
-		// The accleration is always starts at 60 bpm (equal to the pixel rows per second in the
-		// header), and then increases by the following amount (60.22, 60.44, 60.88) for at each foot.
-		// along the roll.
-		double m_tempo_additive_acceleration_per_foot = 0.22;
+		// roll acceleration emulation, in feet per minute per minute. Values
+		// used are based on aggregateed observations of sound and MIDI
+		// recordings of rolls being played on replica hardware, with note
+		// events aligned with distance measurements from scanned roll images.
+		// Default value is for red Welte rolls
+		double m_rollAcceleration = .3087;
 
 };
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4253,10 +4253,18 @@ void RollImage::setMidiFileTempo(MidiFile& midifile) {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
 		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute).
 		midifile.setTPQ(591);
+	} else if (m_rollType == "welte-green") {
+		// Peter Phillips's dissertation describes the speed for green Welte
+		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =
+		// tempo of 70.0532 (* 6 = 420)
+		midifile.setTPQ(420);
 	} else if (m_rollType == "88-note") {
 		midifile.setTPQ(6 * 60); 
 	} else {
 		// set to a neutral guess tempo of 80 for now if unknown, this can be adjusted later.
+		// Note that this is equivalent to the median speed of "eight feet per
+		// minute" that Peter Phillips mentions for the De Luxe Welte Licensee
+		// rolls (p. 126): 8ft/min = 2.4384m/min = tempo of 80.0608
 		midifile.setTPQ(6 * 80); 
 	}
 }

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4217,18 +4217,6 @@ void RollImage::generateHoleMidifile(MidiFile& midifile) {
 
 	// should also add bad holes into track 5 here.
 
-	// add tempo correction
-	double timevalue = 1.0;
-	double tempo;
-	ulongint curtime = 0;
-	double increment = 0.0;
-	while (curtime < maxtime - mintime) {
-		tempo = 60 / timevalue + increment;
-      midifile.addTempo(0, curtime, tempo);
-		curtime += 3600;
-		increment += m_tempo_additive_acceleration_per_foot;
-	}
-
 	midifile.sortTracks();
 }
 #endif
@@ -4246,10 +4234,19 @@ void RollImage::setMidiFileTempo(MidiFile& midifile) {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
 		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute).
 		midifile.setTPQ(591);
+	} else if (m_rollType == "welte-green") {
+		// Peter Phillips's dissertation describes the speed for green Welte
+		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =
+		// tempo of 70.0532 (* 6 = 420).
+		midifile.setTPQ(420);
+		setRollAcceleration(.22336);
 	} else if (m_rollType == "88-note") {
 		midifile.setTPQ(6 * 60); 
 	} else {
 		// set to a neutral guess tempo of 80 for now if unknown, this can be adjusted later.
+		// Note that this is equivalent to the median speed of "eight feet per
+		// minute" that Peter Phillips mentions for the De Luxe Welte Licensee
+		// rolls (p. 126): 8ft/min = 2.4384m/min = tempo of 80.0608
 		midifile.setTPQ(6 * 80); 
 	}
 }
@@ -4443,15 +4440,28 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 	}
 
 	// Add acceleration emulation:
-	double timevalue = 1.0;
-	double tempo;
-	ulongint curtime = 0;
-	double increment = 0.0;
-	while (curtime < maxtime - mintime) {
-		tempo = 60 / timevalue + increment;
-      midifile.addTempo(0, curtime, tempo);
-		curtime += 3600;
-		increment += m_tempo_additive_acceleration_per_foot;
+	// Initial tempo is ticks per beat * 60bpm (in ticks per minute)
+	// Calculate initial velocity in feet per minute by dividing the initial 
+	// tempo in ticks/minute by pixels (ticks) per foot, which is usually
+	// 300 PPI, 1 pixel = 1 tick; 1 ft = 3600 pixels
+	double tpq = (double)midifile.getTPQ();
+	double ppi = getPixelsPerInch();
+	double ticksPerFoot = ppi * 12.0;
+	double currentTempo = 60;
+	double initialSpeed = (tpq * currentTempo) / ticksPerFoot; // ft/min
+	double currentSpeed = initialSpeed;
+	double currentMinute = 0.0;
+	double accelFactor = getRollAcceleration(); // feet per minute per minute
+	ulongint currentTick = 0;
+	double minuteDivision = .1;
+
+	while (currentTick < maxtime - mintime) {
+		cerr << "TEMPO EVENT AT TICK " << currentTick << " tempo " << currentTempo << " minute " << currentMinute << " speed " << currentSpeed << endl;
+		midifile.addTempo(0, currentTick, currentTempo);
+		currentMinute += minuteDivision;
+		currentTick += (int)(currentSpeed * minuteDivision * ticksPerFoot);
+		currentSpeed = initialSpeed + currentMinute * accelFactor;
+		currentTempo = currentSpeed * ticksPerFoot / tpq;
 	}
 
 	midifile.sortTracks();
@@ -4562,7 +4572,7 @@ void RollImage::insertRollImageProperties(MidiFile& midifile) {
 	midifile.addText(0, 0, ss.str()); ss.str("");
 	ss << "@THRESHOLD:\t\t"         << getThreshold()                << "";
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@LENGTH_DPI:\t\t"        << 300.25                        << "ppi";
+	ss << "@LENGTH_DPI:\t\t"        << getPixelsPerInch()            << "ppi";
 	midifile.addText(0, 0, ss.str()); ss.str("");
 	ss << "@IMAGE_WIDTH:\t\t"       << getCols()                     << "px";
 	midifile.addText(0, 0, ss.str()); ss.str("");
@@ -4800,7 +4810,7 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@DRUID:\t\t\t"           << getDruid()                    << "\n";
 	out << "@ROLL_TYPE:\t\t"         << getRollType()                 << "\n";
 	out << "@THRESHOLD:\t\t"         << getThreshold()                << "\n";
-	out << "@LENGTH_DPI:\t\t"        << 300.25                        << "ppi\n";
+	out << "@LENGTH_DPI:\t\t"        << getPixelsPerInch()            << "ppi\n";
 	out << "@IMAGE_WIDTH:\t\t"       << getCols()                     << "px\n";
 	out << "@IMAGE_LENGTH:\t\t"      << getRows()                     << "px\n";
 	out << "@ROLL_WIDTH:\t\t"        << averageRollWidth              << "px\n";

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -64,7 +64,8 @@ void RollImage::clear(void) {
 	m_dustscorebass             = -1.0;
 	m_dustscoretreble           = -1.0;
 	m_averageHoleWidth          = -1.0;
-	m_isMonochrome              = false; 
+	m_isMonochrome              = false;
+	m_useRewindHoleCorrection   = false;
 }
 
 
@@ -124,6 +125,16 @@ string RollImage::my_to_string(int value) {
 //
 void RollImage::setMonochrome(bool value) {
 	m_isMonochrome = value;
+}
+
+
+
+//////////////////////////////
+//
+// RollImage::setRewindCorrection
+//
+void RollImage::setRewindCorrection(bool value) {
+	m_useRewindHoleCorrection = value;
 }
 
 
@@ -491,8 +502,9 @@ void RollImage::assignMidiKeyNumbersToHoles(void) {
 	}
 
 	int rewindholemidi = getRewindHoleMidi();
-	if (!rewindholemidi) {
-		// don't know what type of piano roll or there is no rewind hole, so do
+	if (!rewindholemidi || !m_useRewindHoleCorrection) {
+		// don't know what type of piano roll or there is no rewind hole, or
+		// cmd line specifies not to trust the rewind hole location, so do
 		// not try to make a correction for the expected rewind hole location.
 		return;
 	}

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4435,12 +4435,6 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 		midifile.addNoteOn(track, ontick, channel, hi->midikey, velocity);
 		midifile.addNoteOff(track, offtick, channel, hi->midikey);
 
-		if (hi->offtime <= 0) {
-			cerr << "ERROR OFFTIME IS ZERO: " << hi->offtime << endl;
-		}
-		if (hi->offtime < hi->origin.first) {
-			cerr << "ERROR OFF TIME IS BEFORE ON TIME " << hi->origin.first << " VERSUS " << hi->offtime << " FOR KEY " << hi->midikey << endl;
-		}
 		if (hi->offtime > maxtime) {
 			maxtime = hi->offtime;
 		}

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -789,12 +789,92 @@ void RollImage::analyzeMidiKeyMapping(void) {
 		}
 	}
 
-	// This is to keep the MIDI numbers assigned to holes from being misaligned
-	// by 1, but a refactor is needed to prevent cases like this from happening
-	if ((m_rollType == "welte-red") && (position.size() <= 108)) {
-		leftmostIndex += 1;
-		std::cerr << "shifting leftmostIndex for red Welte roll to " << leftmostIndex << std::endl;
+	std::cerr << "Best fit for leftmost index position based on roll dimensions: " << leftmostIndex << std::endl;
+
+	// Note which potential tracker hole columns contain the leftmost and
+	// rightmost (bassmost and treblemost) holes on the roll
+	int firstColumnIndex = 0;
+	int lastColumnIndex = 0;
+
+	for (ulongint i=0; i<trackerArray.size(); i++) {
+		if (trackerArray[i].size() > 0) {
+			firstColumnIndex = i;
+			break;
+		}
 	}
+	for (ulongint i=trackerArray.size()-1; i>=0; i--) {
+		if (trackerArray[i].size() > 0) {
+			lastColumnIndex = i;
+			break;
+		}
+	}
+
+	// Not all of the tracker hole columns will contain peforations; 88-note
+	// rolls for example may not use several of their leftmost or rightmost
+	// columns
+	int detectedColumns = lastColumnIndex - firstColumnIndex + 1;
+
+	std::cerr << "Leftmost position index with holes: " << firstColumnIndex << std::endl;
+	std::cerr << "Rightmost position index with holes: " << lastColumnIndex << std::endl;
+
+    if (detectedColumns != m_trackerHoles) {
+		std::cerr << "WARNING: expected " << m_trackerHoles << " tracker holes, found " << detectedColumns << std::endl;
+	}
+
+	// Scan all plausible windows of m_trackerHoles columns to see if there is
+	// a better "fit", i.e., a leftmostIndex position that covers more holes
+	// than the starting index identified by the positional logic above.
+	//
+	// Range of leftmostIndex positions to try:
+	// Start: Likely first column based on margins, or leftmost column with
+	//        holes, whichever comes first
+	// End: The last column with holes - the expected number of tracker holes,
+	//      or the leftmost column with holes, whichever comes last
+	int bestLeftIndex = leftmostIndex;
+	int mostHolesCovered = 0;
+	int holesInSpan = 0;
+	for (int j=0; j<m_trackerHoles; j++) {
+	    holesInSpan += trackerArray[leftmostIndex+j].size();
+	}
+	mostHolesCovered = holesInSpan;
+
+	std::cerr << "Holes covered by tracker span starting at " << leftmostIndex << ": " << holesInSpan << std::endl;
+	int i = std::min(firstColumnIndex, leftmostIndex);
+
+	int lastLeftIndex = std::max(lastColumnIndex - m_trackerHoles + 1, firstColumnIndex);
+
+	std::cerr << "Starting index range to scan is " << i << " to " << lastLeftIndex << std::endl;
+
+	while (i <= lastLeftIndex) {
+
+		if (i == leftmostIndex) {
+			i++;
+			continue;
+		}
+
+		holesInSpan = 0;
+		for (int j=0; j<m_trackerHoles; j++) {
+			holesInSpan += trackerArray[i+j].size();
+		}
+
+		std::cerr << "Holes covered by tracker span starting at " << i << ": " << holesInSpan << std::endl;
+
+		// Welte rolls tend to misalign by 1 to the left, so if it's a tie
+		// between the first candidate and the next, choose the starting
+		// position to the right
+		if ((holesInSpan > mostHolesCovered) ||
+		    ((holesInSpan == mostHolesCovered) && 
+			 ((m_rollType == "welte-red") || (m_rollType == "welte-green") || (m_rollType == "welte-licensee")) &&
+			 (i == (leftmostIndex + 1)))) {
+			mostHolesCovered = holesInSpan;
+			bestLeftIndex = i;
+		}
+
+		i++;
+	}
+
+	leftmostIndex = bestLeftIndex;
+	std::cerr << "After considering alternatives, leftmostIndex is now " << leftmostIndex << std::endl;	
 
 	// Initialize the MIDI-to-track mapping:
 	midiToTrackMapping.resize(128);
@@ -802,7 +882,7 @@ void RollImage::analyzeMidiKeyMapping(void) {
 
 	// Assign MIDI key positions to the mapping, starting with
 	// the first position.
-	int count = m_treble_midi - m_bass_midi + 1;
+	int count = m_trackerHoles;
 	for (int i=0; i<count; i++) {
 		midiToTrackMapping.at(i+m_bass_midi) = i+leftmostIndex;
 	}

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4874,6 +4874,10 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	std::time_t current_time = std::chrono::system_clock::to_time_t(nowtime);
 #endif
 
+	// Among other things, this finds the rewind hole, if present, which is 
+	// reported in the ROLLINFO data
+	assignMidiKeyNumbersToHoles();
+
 	out << "@@ This file describes features extracted from a scan of a piano roll.\n";
 	out << "@@ The contents of this file can be converted to JSON format with the\n";
 	out << "@@ ATON.js library from http://aton.sapp.org\n";
@@ -5028,8 +5032,6 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@ \t\t\t   HPIXCOR_TRAIL:\tHorizontal pixel correction of the hole's trailing edge.\n";
 	out << "@@\n";
 	out << "\n";
-
-	assignMidiKeyNumbersToHoles();
 
 	out << "@@BEGIN: HOLES\n\n";
 	for (ulongint i=0; i<holes.size(); i++) {

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -65,7 +65,7 @@ void RollImage::clear(void) {
 	m_dustscoretreble           = -1.0;
 	m_averageHoleWidth          = -1.0;
 	m_isMonochrome              = false;
-	m_useRewindHoleCorrection   = false;
+	m_useRewindHoleCorrection   = true;
 }
 
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -58,6 +58,7 @@ void RollImage::clear(void) {
 	leaderIndex                 = 0;
 	firstMusicRow               = 0;
 	lastMusicRow                = 0;
+	rewindHoleEnd               = 0;
 	m_lastHolePosition          = 0.0;
 	m_firstHolePosition         = 0.0;
 	m_dustscore                 = -1.0;
@@ -3430,6 +3431,17 @@ ulongint RollImage::getLastMusicHoleEnd(void) {
 
 //////////////////////////////
 //
+// RollImage::getRewindHoleEnd --
+//
+
+ulongint RollImage::getRewindHoleEnd(void) {
+	return rewindHoleEnd;
+}
+
+
+
+//////////////////////////////
+//
 // RollImage::markHoleShifts --
 //
 
@@ -4708,6 +4720,8 @@ void RollImage::insertRollImageProperties(MidiFile& midifile) {
 	midifile.addText(0, 0, ss.str()); ss.str("");
 	ss << "@LAST_HOLE:\t\t"         << getLastMusicHoleEnd()         << "px";
 	midifile.addText(0, 0, ss.str()); ss.str("");
+	ss << "@REWIND_HOLE:\t\t"       << getRewindHoleEnd()            << "px";
+	midifile.addText(0, 0, ss.str()); ss.str("");
 	ss << "@END_MARGIN:\t\t"        << getRows() - getLastMusicHoleEnd() << "px";
 	midifile.addText(0, 0, ss.str()); ss.str("");
 	ss << "@MUSICAL_LENGTH:\t"      << musiclength                   << "px";
@@ -4872,6 +4886,7 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@ FIRST_HOLE:\t\t"        << "Pixel row of the first musical hole." << std::endl;
 	out << "@@ LAST_HOLE:\t\t"         << "Pixel row of the end of the last musical hole. Currently includes" << std::endl;
 	out << "@@ \t\t\trewind holes and any punches after the rewind." << std::endl;
+	out << "@@ REWIND_HOLE:\t\t"       << "Last pixel row of the detected rewind hole if found, otherwise 0." << std::endl;
 	out << "@@ END_MARGIN:\t\t"        << "IMAGE_LENGTH - LAST_HOLE." << std::endl;
 	out << "@@ MUSICAL_LENGTH:\t"      << "Pixel row count from the first music hole to the end of" << std::endl;
 	out << "@@ \t\t\tthe last music hole." << std::endl;
@@ -4930,6 +4945,7 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@LEADER_ROW:\t\t"        << getLeaderIndex()              << "px\n";
 	out << "@FIRST_HOLE:\t\t"        << getFirstMusicHoleStart()      << "px\n";
 	out << "@LAST_HOLE:\t\t"         << getLastMusicHoleEnd()         << "px\n";
+	out << "@REWIND_HOLE:\t\t"       << getRewindHoleEnd()            << "px\n";
 	out << "@END_MARGIN:\t\t"        << getRows() - getLastMusicHoleEnd() << "px\n";
 	out << "@MUSICAL_LENGTH:\t"      << musiclength                   << "px\n";
 	out << "@MUSICAL_HOLES:\t\t"     << holes.size()                  << "\n";

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -3253,6 +3253,7 @@ void RollImage::recalculateFirstMusicHole(void) {
 	ulongint minrow = getRows() - 1;
 	std::vector<std::vector<HoleInfo*> >& ta = trackerArray;
 	ulongint row;
+	ulongint nextMusicRow = minrow;
 	for (ulongint i=0; i<ta.size(); i++) {
 		for (ulongint j=0; j<ta[i].size(); j++) {
 			if (!ta[i][j]->isMusicHole()) {
@@ -3261,9 +3262,19 @@ void RollImage::recalculateFirstMusicHole(void) {
 			row = ta[i][j]->origin.first;
 			if (row < minrow) {
 				minrow = row;
+			} else if (row < nextMusicRow) {
+				nextMusicRow = row;
 			}
 		}
 	}
+
+	// Use a conservative distance (2.8 ft) so that only punctures and obvious
+	// outliers appearing well above the rest of the roll are disregarded.
+	if ((nextMusicRow > minrow) && ((nextMusicRow - minrow) > 10000)) {
+		cerr << "FIRST MUSIC HOLE MUCH EARLIER THAN NEXT: " << minrow << " -> " << nextMusicRow << ", SKIPPING" << endl;
+		minrow = nextMusicRow;
+	}
+
 	if (minrow > firstMusicRow) {
 		firstMusicRow = minrow;
 		markPosteriorLeader();

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4232,8 +4232,9 @@ void RollImage::generateHoleMidifile(MidiFile& midifile) {
 void RollImage::setMidiFileTempo(MidiFile& midifile) {
 	if (m_rollType == "welte-red") {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
-		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute).
-		midifile.setTPQ(591);
+		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute)
+		// 568 is the currently preferred value, however.
+		midifile.setTPQ(568);
 	} else if (m_rollType == "welte-green") {
 		// Peter Phillips's dissertation describes the speed for green Welte
 		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4346,12 +4346,13 @@ void RollImage::generateHoleMidifile(MidiFile& midifile) {
 void RollImage::setMidiFileTempo(MidiFile& midifile) {
 	if (m_rollType == "welte-red") {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
-		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute).
-		midifile.setTPQ(591);
+		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute)
+		// 568 is the currently preferred value, however.
+		midifile.setTPQ(568);
 	} else if (m_rollType == "welte-green") {
 		// Peter Phillips's dissertation describes the speed for green Welte
 		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =
-		// tempo of 70.0532 (* 6 = 420).
+		// tempo of 70.0532 (* 6 = 420)
 		midifile.setTPQ(420);
 		setRollAcceleration(.22336);
 	} else if (m_rollType == "88-note") {

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -5011,8 +5011,9 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@ \t\t\taround the hole.\n";
 	out << "@@ ORIGIN_COL:\t\tThe pixel column of the leading edge of the bounding box around" << std::endl;
 	out << "@@ \t\t\tthe hole, bass side.\n";
-	out << "@@ WIDTH_ROW:\t\tThe pixel length of the bounding box around the hole.\n";
-	out << "@@ WIDTH_COL:\t\tThe pixel column of the leading edge of the hole, bass side.\n";
+	out << "@@ WIDTH_ROW:\t\\Length in pixels from the leading row of the hole's bounding box" << std::endl;
+	out << "@@ \t\t\tto the trailing edge's row.\n";
+	out << "@@ WIDTH_COL:\t\tWidth in pixels from the bass-side to the treble-side edge of the hole.\n";
 	out << "@@ CENTROID_ROW:\tThe center of mass row of the hole.\n";
 	out << "@@ CENTROID_COL:\tThe center of mass column of the hole.\n";
 	out << "@@ AREA:\t\tThe area of the hole (in pixels).\n";

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4423,18 +4423,13 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 			velocity = velocitynormal;
 		}
 
-		// PMB Set tick of (likely spurious) holes before the first music hole to 0; otherwise their
-		// tick values can be negative, which corrupts the output.
+		// Skip likely spurious holes appearing before the first music hole.
 		int ontick = hi->origin.first - mintime;
 		int offtick = hi->offtime - mintime;
 
-		if (ontick < 0) {
-			cerr << "ERROR ON TIME LESS THAN ZERO: " << ontick << " FOR KEY " << hi->midikey << endl;
-			ontick = 0;
-		}
-		if (offtick < 0) {
-			cerr << "ERROR OFF TIME LESS THAN ZERO: " << offtick << " FOR KEY " << hi->midikey << endl;
-			offtick = 0;
+		if ((ontick < 0) || (offtick < 0)) {
+			cerr << "NOTE ON TICK OR OFF TICK LESS THAN ZERO: " << ontick << " -> " << offtick << " FOR KEY " << hi->midikey << ", SKIPPING" << endl;
+			continue;
 		}
 
 		midifile.addNoteOn(track, ontick, channel, hi->midikey, velocity);

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4874,8 +4874,6 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	std::time_t current_time = std::chrono::system_clock::to_time_t(nowtime);
 #endif
 
-	// Among other things, this finds the rewind hole, if present, which is 
-	// reported in the ROLLINFO data
 	assignMidiKeyNumbersToHoles();
 
 	out << "@@ This file describes features extracted from a scan of a piano roll.\n";

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -48,6 +48,7 @@ void RollOptions::reset(void) {
 	m_minTrackerSpacingToPaperEdge = 0.50;
 	m_maxHoleWidth                 = 1.50; // wide for rewind hole of duoart salesman
 	m_aspectRatioThreshold         = 1.25;
+	m_pixelsPerInch                = 300;
 	m_majorAxisThreshold           = 13.0;
 	m_circularityThreshold         =  0.4;
 	m_maxHoleCount                 = 100000;
@@ -55,6 +56,17 @@ void RollOptions::reset(void) {
 	m_attackLineSpacing            = 10;
 	m_holeShiftCutoff              = 3.0;
 };
+
+
+
+//////////////////////////////
+//
+// RollOptions::getPixelsPerInch -- 
+//
+
+double RollOptions::getPixelsPerInch(void) {
+	return m_pixelsPerInch;
+}
 
 
 
@@ -595,6 +607,28 @@ void RollOptions::setThreshold(int value) {
 
 int RollOptions::getThreshold(void) {
 	return (ucharint)m_threshold;
+}
+
+
+
+//////////////////////////////
+//
+// RollOptions::setRollAcceleration -- 
+//
+
+void RollOptions::setRollAcceleration(double value) {
+	m_rollAcceleration = value;
+}
+
+
+
+//////////////////////////////
+//
+// RollOptions::getRollAcceleration -- 
+//
+
+double RollOptions::getRollAcceleration(void) {
+	return m_rollAcceleration;
 }
 
 

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -509,13 +509,13 @@ void RollOptions::setRollType88Note(void) {
 	m_bassNotesTrackStartNumberLeft = 7;
 	m_bassNotesTrackStartMidi = 21;
 
-	// treble expression (not used)
+	// treble expression (not really used except for snakebite accents)
 	m_trebleNotesTrackStartNumberLeft = 51;
 	m_trebleNotesTrackStartMidi = 65;
 	m_trebleExpressionTrackStartNumberLeft = 95;
 	m_trebleExpressionTrackStartMidi = 109;
 
-	hasNoExpressionMidiFileSetup();
+	hasExpressionMidiFileSetup();
 }
 
 

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -343,7 +343,7 @@ void RollOptions::setRollTypeRedWelte(void) {
 
 //////////////////////////////
 //
-// RollOptions::setRollTypeGreenWelte -- Apply settings suitable for Red Welte (T-98) piano rolls.
+// RollOptions::setRollTypeGreenWelte -- Apply settings suitable for Green Welte (T-98) piano rolls.
 //
 // Peter Phillips dissertation: https://ses.library.usyd.edu.au/bitstream/2123/16939/1/Piano%20Rolls.pdf
 //
@@ -355,14 +355,14 @@ void RollOptions::setRollTypeRedWelte(void) {
 //       3:  Sustain pedal                   MIDI Key 18
 //       4:  Bass Crescendo                  MIDI Key 19
 //       5:  Bass Sforzando forte            MIDI Key 20
-//   Then 88 notes from C0 to C8 (MIDI notes 21 to 108) (but actually only 80 used)
+//   Then 88 notes from A0 to C8 (MIDI notes 21 to 108)
 //       6: A0                               MIDI Key 21
 //       ...
 //       51:  F#4                            MIDI Key 66
 //    Treble register:
 //       52:  G4                             MIDI Key 67
 //       ...
-//       93:  G7                             MIDI Key 108
+//       93:  C8                             MIDI Key 108
 //   5 expression holes on the treble side:
 //       94:  -5:  Treble Sforzando forte    MIDI Key 109
 //       95:  -4:  Treble Crescendo          MIDI Key 110
@@ -372,9 +372,6 @@ void RollOptions::setRollTypeRedWelte(void) {
 //
 
 void RollOptions::setRollTypeGreenWelte(void) {
-	cerr << "GREEN ROLL NOT IMPLEMENT YET" << endl;
-	exit(1);
-
 	m_rollType = "welte-green";
 	m_minTrackerSpacingToPaperEdge = 1.6; // check
 	m_rewindHole = 1;  // 1st hole from left (bass), but only if "long"
@@ -389,7 +386,7 @@ void RollOptions::setRollTypeGreenWelte(void) {
 	m_bassNotesTrackStartNumberLeft = 6;
 	m_bassNotesTrackStartMidi = 21;
 
-	m_trebleNotesTrackStartNumberLeft = 54;
+	m_trebleNotesTrackStartNumberLeft = 52;
 	m_trebleNotesTrackStartMidi = 67;
 
 	m_trebleExpressionTrackStartNumberLeft = 94;

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -263,7 +263,7 @@ void RollOptions::setHoleShiftCutoff(double value) {
 //   "" = unknown/unspecified
 //   "welte-red"      = Welte Mignon T-100 red roll
 //   "welte-green"    = Welte Mignon T-98 green roll
-//   "welte-licensee" = Welte Mignon (Deluxe) Licensee
+//   "welte-licensee" = Welte Mignon (De Luxe) Licensee
 //   "ampico"         = AMPICO roll (variation not specified)
 //   "ampico-a"       = AMPICO roll, earlier model
 //   "ampico-b"       = AMPICO roll, later model
@@ -394,6 +394,68 @@ void RollOptions::setRollTypeGreenWelte(void) {
 
 	m_trebleExpressionTrackStartNumberLeft = 94;
 	m_trebleExpressionTrackStartMidi = 109;
+
+	hasExpressionMidiFileSetup();
+}
+
+
+
+//////////////////////////////
+//
+// RollOptions::setRollTypeLicenseeWelte -- Apply settings suitable for Welte Licensee (US De Luxe) piano rolls.
+//
+// Welte Licensee tracker holes:
+//
+//   8 expression holes on bass side:
+//       1:  Bass Mezzoforte off             MIDI Key 16
+//       2:  Bass Mezzoforte on              MIDI Key 17
+//       3:  Bass Crescendo off              MIDI Key 18
+//       4:  Bass Crescendo on               MIDI Key 19
+//       5:  Bass Sforzando off              MIDI Key 20
+//       6:  Bass Sforzando on               MIDI Key 21
+//       7:  Soft pedal on                   MIDI Key 22
+//       8:  Soft pedal off                  MIDI Key 23
+//   Then 80 notes from C1 to G7 (MIDI notes 24 to 103)
+//       9:  C1                              MIDI Key 24
+//       ...
+//       51:  F#4                            MIDI Key 66
+//    Treble register:
+//       52:  G4                             MIDI Key 67
+//       ...
+//       88:  G7                             MIDI Key 103
+//   10 expression holes on the treble side:
+//       89: -10:  Rewind                    MIDI Key 104
+//       90:  -9:  Blank                    [MIDI Key 105]
+//       91:  -8:  Sustain pedal on          MIDI Key 106
+//       92:  -7:  Sustain pedal off         MIDI Key 107
+//       93:  -6:  Treble Sforzando on       MIDI Key 108
+//       94:  -5:  Treble Sforzando off      MIDI Key 109
+//       95:  -4:  Treble Crescendo on       MIDI Key 110
+//       96:  -3:  Treble Crescendo off      MIDI Key 111
+//       97:  -2:  Treble Mezzoforte on      MIDI Key 112
+//       98:  -1:  Treble Mezzoforte off     MIDI Key 113
+//		 
+
+void RollOptions::setRollTypeLicenseeWelte(void) {
+	m_rollType = "welte-licensee";
+	m_minTrackerSpacingToPaperEdge = 1.6; // check
+	m_rewindHole = 89;
+	m_rewindHoleMidi = 104;
+	m_trackerHoles = 98;
+
+	m_bass_midi = 16;   // first MIDI Note on bass side of paper
+	m_treble_midi = 113; // first MIDI Note on treble side of paper
+
+	m_bassExpressionTrackStartNumberLeft = 1;
+	m_bassExpressionTrackStartMidi = 16;
+	m_bassNotesTrackStartNumberLeft = 9;
+	m_bassNotesTrackStartMidi = 24;
+
+	m_trebleNotesTrackStartNumberLeft = 52;
+	m_trebleNotesTrackStartMidi = 67;
+
+	m_trebleExpressionTrackStartNumberLeft = 89;
+	m_trebleExpressionTrackStartMidi = 104;
 
 	hasExpressionMidiFileSetup();
 }

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -467,9 +467,9 @@ void RollOptions::setRollType65Note(void) {
 //       1        15      unused
 //       2        16      unused, sometimes rewind hole
 //       3        17      unused
-//       4        18      sustain pedal
-//       5        19      unused
-//       6        20      unused
+//       4        18      Sustain pedal
+//       5        19      Bass snakebite accent
+//       6        20      Bass snakebite accent
 //       7        21      A0
 //       ...
 //       50       64      E4  Pretend Bass register
@@ -477,8 +477,8 @@ void RollOptions::setRollType65Note(void) {
 //       51       65      F4  Pretend Treble register
 //       ...
 //       94      108      C7
-//       95      109      unused
-//       96      110      unused
+//       95      109      Treble snakebite accent
+//       96      110      Treble snakebite accent
 //       97      111      unused
 //       98      112      unused
 //       99      113      unused

--- a/tools/markholes.cpp
+++ b/tools/markholes.cpp
@@ -15,7 +15,7 @@
 //                    bin/markholes input.tiff copy.tiff > analysis.txt
 // Options:
 //     -r         Assume a Red Welte-Mignon piano roll (T-100).
-//     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
+//     -g         Assume a Green Welte-Mignon piano roll (T-98).
 //     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll.
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
@@ -38,7 +38,7 @@ using namespace rip;
 int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
-	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
+	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll");
 	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");

--- a/tools/markholes.cpp
+++ b/tools/markholes.cpp
@@ -16,7 +16,7 @@
 // Options:
 //     -r         Assume a Red Welte-Mignon piano roll (T-100).
 //     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
-//     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll, but option not yet active.
+//     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll.
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
 //     -d         Assume a Duo-Art piano roll, but option not yet active.
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
 	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
-	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll (option not active yet)");
+	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
 	options.define("d|duo-art=b", "Assume Aeolean Duo-Art piano roll (option not active yet)");
@@ -65,6 +65,8 @@ int main(int argc, char** argv) {
 		roll.setRollTypeRedWelte();
 	} else if (options.getBoolean("green-welte")) {
 		roll.setRollTypeGreenWelte();
+	} else if (options.getBoolean("licensee-welte")) {
+		roll.setRollTypeLicenseeWelte();
 	} else if (options.getBoolean("65-note")) {
 		roll.setRollType65Note();
 	} else if (options.getBoolean("88-note")) {
@@ -73,6 +75,7 @@ int main(int argc, char** argv) {
 		cerr << "A Roll type is required:" << endl;
 		cerr << "   -r   == for red Welte rolls"   << endl;
 		cerr << "   -g   == for green Welte rolls" << endl;
+		cerr << "   -l   == for Licensee Welte rolls" << endl;
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -12,7 +12,7 @@
 //                markup of the copy of the input image.
 // Options:
 //     -r         Assume a Red Welte-Mignon piano roll (T-100).
-//     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
+//     -g         Assume a Green Welte-Mignon piano roll (T-98).
 //     -l         Assume a Welte-Mignon (De Luxe) Licensee piano roll
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
@@ -35,7 +35,7 @@ using namespace rip;
 int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
-	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
+	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll");
 	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
-		cerr << "Usage: tiff2holes [-rl58tm] file.tiff > analysis.txt" << endl;
+		cerr << "Usage: tiff2holes [-rgl58tm] file.tiff > analysis.txt" << endl;
 		cerr << "file.tiff must be a 24-bit color image, uncompressed" << endl;
 		cerr << "unless -m is supplied; then file.tiff must be a monochrome" << endl;
 		cerr << "(8-bit, single-channel) image, uncompressed" << endl;

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -11,9 +11,9 @@
 //                program as markholes.cpp, but this one does not do analytic
 //                markup of the copy of the input image.
 // Options:
-//     -r         Assume a Red Welte-Mignon piano roll (T-100). (currently hard-wired on until more roll types implemented)
+//     -r         Assume a Red Welte-Mignon piano roll (T-100).
 //     -g         Assume a Green Welte-Mignon piano roll (T-98), but option not yet active.
-//     -l         Assume a Welte-Mignon (Deluxe) Licensee piano roll, but option not yet active.
+//     -l         Assume a Welte-Mignon (De Luxe) Licensee piano roll
 //     -a         Assume an Ampico [A] (older) piano roll, but option not yet active.
 //     -b         Assume an Ampico B (newer) piano roll, but option not yet active.
 //     -d         Assume a Duo-Art piano roll, but option not yet active.
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 	Options options;
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
 	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll (option not active yet)");
-	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll (option not active yet)");
+	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
 	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
 	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
 	options.define("d|duo-art=b", "Assume Aeolean Duo-Art piano roll (option not active yet)");
@@ -47,8 +47,10 @@ int main(int argc, char** argv) {
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
-		cerr << "Usage: tiff2holes [-rt] file.tiff > analysis.txt" << endl;
+		cerr << "Usage: tiff2holes [-rl58tm] file.tiff > analysis.txt" << endl;
 		cerr << "file.tiff must be a 24-bit color image, uncompressed" << endl;
+		cerr << "unless -m is supplied; then file.tiff must be a monochrome" << endl;
+		cerr << "(8-bit, single-channel) image, uncompressed" << endl;
 		exit(1);
 	}
 
@@ -62,6 +64,8 @@ int main(int argc, char** argv) {
 		roll.setRollTypeRedWelte();
 	} else if (options.getBoolean("green-welte")) {
 		roll.setRollTypeGreenWelte();
+	} else if (options.getBoolean("licensee-welte")) {
+		roll.setRollTypeLicenseeWelte();
 	} else if (options.getBoolean("65-note")) {
 		roll.setRollType65Note();
 	} else if (options.getBoolean("88-note")) {
@@ -70,6 +74,7 @@ int main(int argc, char** argv) {
 		cerr << "A Roll type is required:" << endl;
 		cerr << "   -r   == for red Welte rolls"   << endl;
 		cerr << "   -g   == for green Welte rolls" << endl;
+		cerr << "   -l   == for Licensee Welte rolls" << endl;
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
 	options.define("8|88|88-note|88-hole=b", "Assume 88-note roll");
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");
 	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
+	options.define("s|disregard-rewind-hole=b", "Skip rewind hole correction for tracker->MIDI mapping");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
@@ -78,6 +79,10 @@ int main(int argc, char** argv) {
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);
+	}
+
+    if (options.getBoolean("disregard-rewind-hole")) {
+		roll.setRewindCorrection(false);
 	}
 
 	int threshold = options.getInteger("threshold");


### PR DESCRIPTION
The y coordinate of the end pixel will be stored in the roll parser report (and in the MIDI metadata track) as `@REWIND_HOLE`. If not found, it will be `0px`.