### PR TITLE
Add cmd line switch to enable/disable acceleration emulation

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -90,6 +90,7 @@ class RollImage : public TiffFile, public RollOptions {
 		void	        loadGreenChannel              (int threshold);
 		void	        setMonochrome                 (bool value);
 		void            setRewindCorrection           (bool value);
+		void            toggleAccelerationEmulation   (bool value);
 		void            analyze                       (void);
 		void            analyzeHoles                  (void);
 		void            mergePixelOverlay             (std::fstream& output);
@@ -343,6 +344,7 @@ class RollImage : public TiffFile, public RollOptions {
 		double     m_averageHoleWidth;
 		bool       m_isMonochrome;
 		bool       m_useRewindHoleCorrection;
+		bool       m_emulateAcceleration;
 
 #ifndef DONOTUSEFFT
 		std::chrono::system_clock::time_point start_time;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4580,6 +4580,8 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 	}
 
 	if (!m_emulateAcceleration) {
+		midifile.addTempo(0, 0, 60);
+		midifile.sortTracks();
 		return;
 	}
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -66,6 +66,7 @@ void RollImage::clear(void) {
 	m_averageHoleWidth          = -1.0;
 	m_isMonochrome              = false;
 	m_useRewindHoleCorrection   = true;
+	m_emulateAcceleration       = false;
 }
 
 
@@ -135,6 +136,16 @@ void RollImage::setMonochrome(bool value) {
 //
 void RollImage::setRewindCorrection(bool value) {
 	m_useRewindHoleCorrection = value;
+}
+
+
+
+//////////////////////////////
+//
+// RollImage::toggleAccelerationEmulation
+//
+void RollImage::toggleAccelerationEmulation(bool value) {
+	m_emulateAcceleration = value;
 }
 
 
@@ -4566,6 +4577,10 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 		if (hi->offtime > maxtime) {
 			maxtime = hi->offtime;
 		}
+	}
+
+	if (!m_emulateAcceleration) {
+		return;
 	}
 
 	// Add acceleration emulation:

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4995,8 +4995,9 @@ std::ostream& RollImage::printRollImageProperties(std::ostream& out) {
 	out << "@@ \t\t\taround the hole.\n";
 	out << "@@ ORIGIN_COL:\t\tThe pixel column of the leading edge of the bounding box around" << std::endl;
 	out << "@@ \t\t\tthe hole, bass side.\n";
-	out << "@@ WIDTH_ROW:\t\tThe pixel length of the bounding box around the hole.\n";
-	out << "@@ WIDTH_COL:\t\tThe pixel column of the leading edge of the hole, bass side.\n";
+	out << "@@ WIDTH_ROW:\t\\Length in pixels from the leading row of the hole's bounding box" << std::endl;
+	out << "@@ \t\t\tto the trailing edge's row.\n";
+	out << "@@ WIDTH_COL:\t\tWidth in pixels from the bass-side to the treble-side edge of the hole.\n";
 	out << "@@ CENTROID_ROW:\tThe center of mass row of the hole.\n";
 	out << "@@ CENTROID_COL:\tThe center of mass column of the hole.\n";
 	out << "@@ AREA:\t\tThe area of the hole (in pixels).\n";

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv) {
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");
 	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
 	options.define("s|disregard-rewind-hole=b", "Skip rewind hole correction for tracker->MIDI mapping");
+	options.define("e|emulate-roll-acceleration=b", "Add tempo events to note MIDI for acceleration");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
@@ -83,6 +84,10 @@ int main(int argc, char** argv) {
 
     if (options.getBoolean("disregard-rewind-hole")) {
 		roll.setRewindCorrection(false);
+	}
+
+	if (options.getBoolean("emulate-roll-acceleration")) {
+		roll.toggleAccelerationEmulation(true);
 	}
 
 	int threshold = options.getInteger("threshold");

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
-		cerr << "Usage: tiff2holes [-rgl58tm] file.tiff > analysis.txt" << endl;
+		cerr << "Usage: tiff2holes [-rgl58tmse] file.tiff > analysis.txt" << endl;
 		cerr << "file.tiff must be a 24-bit color image, uncompressed" << endl;
 		cerr << "unless -m is supplied; then file.tiff must be a monochrome" << endl;
 		cerr << "(8-bit, single-channel) image, uncompressed" << endl;


### PR DESCRIPTION
If the `-e` switch is provided to `tiff2holes`, the note MIDI file will have tempo events added to emulate acceleration using the new algorithm from PR #13. Otherwise, the MIDI file will not accelerate and will remain at 60bpm for the entire duration. The raw MIDI file will never have acceleration-based tempo events applied to it.