### PR TITLE
Refine MIDI metadata

### DIFF
--- a/src/HoleInfo.cpp
+++ b/src/HoleInfo.cpp
@@ -103,34 +103,34 @@ std::ostream& HoleInfo::printAton(std::ostream& out) {
 	if (!id.empty()) {
 		out << "@ID:\t\t" << id << std::endl;
 	}
-	out << "@ORIGIN_ROW:\t"   << origin.first     << "px"  << std::endl;
-	out << "@ORIGIN_COL:\t"   << origin.second    << "px"  << std::endl;
-	out << "@WIDTH_ROW:\t"    << width.first      << "px"  << std::endl;
-	out << "@WIDTH_COL:\t"    << width.second     << "px"  << std::endl;
-	out << "@CENTROID_ROW:\t" << centroid.first   << "px"  << std::endl;
-	out << "@CENTROID_COL:\t" << centroid.second  << "px"  << std::endl;
-	out << "@AREA:\t\t"       << area             << "px"  << std::endl;
-	out << "@PERIMETER:\t"    << perimeter        << "px"  << std::endl;
+	out << "@ORIGIN_ROW:\t"   << origin.first     << std::endl;
+	out << "@ORIGIN_COL:\t"   << origin.second    << std::endl;
+	out << "@WIDTH_ROW:\t"    << width.first      << std::endl;
+	out << "@WIDTH_COL:\t"    << width.second     << std::endl;
+	out << "@CENTROID_ROW:\t" << centroid.first   << std::endl;
+	out << "@CENTROID_COL:\t" << centroid.second  << std::endl;
+	out << "@AREA:\t\t"       << area             << std::endl;
+	out << "@PERIMETER:\t"    << perimeter        << std::endl;
 	out << "@CIRCULARITY:\t"  << int(circularity*100.0+0.5)/100.0 << std::endl;
 
 	if (attack) {
-		out << "@NOTE_ATTACK:\t" << origin.first << "px" << std::endl;
-		out << "@OFF_TIME:\t"    << offtime      << "px" << std::endl;
+		out << "@NOTE_ATTACK:\t" << origin.first  << std::endl;
+		out << "@OFF_TIME:\t"    << offtime       << std::endl;
 	}
-	out << "@TRACKER_HOLE:\t" << track               << std::endl;
-	out << "@MIDI_KEY:\t"     << midikey             << std::endl;
+	out << "@TRACKER_HOLE:\t" << track            << std::endl;
+	out << "@MIDI_KEY:\t"     << midikey          << std::endl;
 
 	#define HOLE_SHIFT 3.0
 
 	if (std::fabs(leadinghcor - trailinghcor) < HOLE_SHIFT) {
 		double value = (leadinghcor + trailinghcor) / 2.0;
 		value = int(value * 10 + 0.5)/10.0;
-		out << "@HPIXCOR:\t"        << value   << "px" << std::endl;
+		out << "@HPIXCOR:\t"        << value      << std::endl;
 	} else {
 		double value1 = int(leadinghcor*10.0+0.5)/10.0;
 		double value2 = int(trailinghcor*10.0+0.5)/10.0;
-		out << "@HPIXCOR_LEAD:\t"  << value1   << "px" << std::endl;
-		out << "@HPIXCOR_TRAIL:\t" << value2   << "px" << std::endl;
+		out << "@HPIXCOR_LEAD:\t"  << value1      << std::endl;
+		out << "@HPIXCOR_TRAIL:\t" << value2      << std::endl;
 	}
 
 	// if (!isMusicHole) {

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4265,15 +4265,18 @@ void RollImage::generateHoleMidifile(MidiFile& midifile) {
 	string filename = getDruid();
 	if (!filename.empty()) {
 		filename += "-raw.mid";
-		string entry = "@FILENAME:\t\t";
+		string entry = "@FILENAME:\t";
 		entry += filename;
 		midifile.addText(0, 0, entry);
 	}
 
 	insertRollImageProperties(midifile);
-	midifile.addText(0, 0, "@MIDIFILE_TYPE:\t\thole");
+	midifile.addText(0, 0, "@MIDIFILE_TYPE:\thole");
 
 	setMidiFileTempo(midifile);
+	stringstream ss;
+	ss << "@TICKS_PER_QUARTER:\t" << midifile.getTPQ();
+	midifile.addText(0, 0, ss.str());
 
 	// Tracks are organized by real notes first, then expression tracks.
 	// This is so that the expression tracks can be easily thrown away
@@ -4419,15 +4422,18 @@ void RollImage::generateMidifile(MidiFile& midifile) {
 	string filename = getDruid();
 	if (!filename.empty()) {
 		filename += ".mid";
-		string entry = "@FILENAME:\t\t";
+		string entry = "@FILENAME:\t";
 		entry += filename;
 		midifile.addText(0, 0, entry);
 	}
 
 	insertRollImageProperties(midifile);
-	midifile.addText(0, 0, "@MIDIFILE_TYPE:\t\tnote");
+	midifile.addText(0, 0, "@MIDIFILE_TYPE:\tnote");
 
 	setMidiFileTempo(midifile);
+	stringstream ss;
+	ss << "@TICKS_PER_QUARTER:\t" << midifile.getTPQ();
+	midifile.addText(0, 0, ss.str());
 
 	// These are the values to use for 300 dpi images:
 	// tempo 30 = 180
@@ -4712,104 +4718,104 @@ void RollImage::insertRollImageProperties(MidiFile& midifile) {
 #endif
 
 	stringstream ss;
-	ss << "@DRUID:\t\t\t"            << getDruid()                   << "";
+	ss << "@DRUID:\t"               << getDruid();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@ROLL_TYPE:\t\t"         << getRollType()                 << "";
+	ss << "@ROLL_TYPE:\t"           << getRollType();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@THRESHOLD:\t\t"         << getThreshold()                << "";
+	ss << "@THRESHOLD:\t"           << getThreshold();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@LENGTH_DPI:\t\t"        << getPixelsPerInch()            << "ppi";
+	ss << "@LENGTH_DPI:\t"          << getPixelsPerInch();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@IMAGE_WIDTH:\t\t"       << getCols()                     << "px";
+	ss << "@IMAGE_WIDTH:\t"         << getCols();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@IMAGE_LENGTH:\t\t"      << getRows()                     << "px";
+	ss << "@IMAGE_LENGTH:\t"        << getRows();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@ROLL_WIDTH:\t\t"        << averageRollWidth              << "px";
+	ss << "@ROLL_WIDTH:\t"          << averageRollWidth;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@HARD_MARGIN_BASS:\t"    << getHardMarginLeftWidth()      << "px";
+	ss << "@HARD_MARGIN_BASS:\t"    << getHardMarginLeftWidth();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@HARD_MARGIN_TREBLE:\t"  << getHardMarginRightWidth()     << "px";
+	ss << "@HARD_MARGIN_TREBLE:\t"  << getHardMarginRightWidth();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@MAX_BASS_DRIFT:\t"      << getSoftMarginLeftWidthMax()   << "px";
+	ss << "@MAX_BASS_DRIFT:\t"      << getSoftMarginLeftWidthMax();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@MAX_TREBLE_DRIFT:\t"    << getSoftMarginRightWidthMax()  << "px";
+	ss << "@MAX_TREBLE_DRIFT:\t"    << getSoftMarginRightWidthMax();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@AVG_SOFT_MARGIN_SUM:\t" << averageSoftMarginWidth        << "px";
+	ss << "@AVG_SOFT_MARGIN_SUM:\t" << averageSoftMarginWidth;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@DRIFT_RANGE:\t\t"       << int(driftrange*100+0.5)/100.0 << "px";
+	ss << "@DRIFT_RANGE:\t"         << int(driftrange*100+0.5)/100.0;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@DRIFT_MIN:\t\t"         << int(driftmax*100+0.5)/100.0   << "px";
+	ss << "@DRIFT_MIN:\t"           << int(driftmax*100+0.5)/100.0;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@DRIFT_MAX:\t\t"         << int(driftmin*100+0.5)/100.0   << "px";
+	ss << "@DRIFT_MAX:\t"           << int(driftmin*100+0.5)/100.0;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@PRELEADER_ROW:\t\t"     << getPreleaderIndex()           << "px";
+	ss << "@PRELEADER_ROW:\t"       << getPreleaderIndex();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@LEADER_ROW:\t\t"        << getLeaderIndex()              << "px";
+	ss << "@LEADER_ROW:\t"          << getLeaderIndex();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@FIRST_HOLE:\t\t"        << getFirstMusicHoleStart()      << "px";
+	ss << "@FIRST_HOLE:\t"          << getFirstMusicHoleStart();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@LAST_HOLE:\t\t"         << getLastMusicHoleEnd()         << "px";
+	ss << "@LAST_HOLE:\t"           << getLastMusicHoleEnd();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@END_MARGIN:\t\t"        << getRows() - getLastMusicHoleEnd() << "px";
+	ss << "@END_MARGIN:\t"          << getRows() - getLastMusicHoleEnd();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@MUSICAL_LENGTH:\t"      << musiclength                   << "px";
+	ss << "@MUSICAL_LENGTH:\t"      << musiclength;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@MUSICAL_HOLES:\t\t"     << holes.size()                  << "";
+	ss << "@MUSICAL_HOLES:\t"       << holes.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@MUSICAL_NOTES:\t\t"     << musicnotecount                << "";
+	ss << "@MUSICAL_NOTES:\t"       << musicnotecount;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@AVG_HOLE_WIDTH:\t"      << avgholewidth                  << "px";
+	ss << "@AVG_HOLE_WIDTH:\t"      << avgholewidth;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@ANTIDUST_COUNT:\t"      << antidust.size()               << "";
+	ss << "@ANTIDUST_COUNT:\t"      << antidust.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@BAD_HOLE_COUNT:\t"      << badHoles.size()               << "";
+	ss << "@BAD_HOLE_COUNT:\t"      << badHoles.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@EDGE_TEAR_COUNT:\t"     << trebleTears.size() + bassTears.size() << "";
+	ss << "@EDGE_TEAR_COUNT:\t"     << trebleTears.size() + bassTears.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@BASS_TEAR_COUNT:\t"     << bassTears.size()              << "";
+	ss << "@BASS_TEAR_COUNT:\t"     << bassTears.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@TREBLE_TEAR_COUNT:\t"   << trebleTears.size()            << "";
+	ss << "@TREBLE_TEAR_COUNT:\t"   << trebleTears.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@DUST_SCORE:\t\t"        << int(getDustScore()+0.5)       << "ppm";
+	ss << "@DUST_SCORE:\t"          << int(getDustScore()+0.5) << " ppm";
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@DUST_SCORE_BASS:\t"     << int(getDustScoreBass()+0.5)   << "ppm";
+	ss << "@DUST_SCORE_BASS:\t"     << int(getDustScoreBass()+0.5) << " ppm";
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@DUST_SCORE_TREBLE:\t"   << int(getDustScoreTreble()+0.5) << "ppm";
+	ss << "@DUST_SCORE_TREBLE:\t"   << int(getDustScoreTreble()+0.5) << " ppm";
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@SHIFTS:\t\t"            << shifts.size()                 << "";
+	ss << "@SHIFTS:\t"              << shifts.size();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@HOLE_SEPARATION:\t"     << holeSeparation                << "px";
+	ss << "@HOLE_SEPARATION:\t"     << holeSeparation;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@HOLE_OFFSET:\t\t"       << holeOffset                    << "px";
+	ss << "@HOLE_OFFSET:\t"         << holeOffset;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@TRACKER_HOLES:\t\t"     << trackerholes                  << "";
+	ss << "@TRACKER_HOLES:\t"       << trackerholes;
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@HOLE_SOFTWARE:\t\t"     << "https://github.com/pianoroll/roll-image-parser" << "";
+	ss << "@HOLE_SOFTWARE:\t"       << "https://github.com/pianoroll/roll-image-parser";
 	midifile.addText(0, 0, ss.str()); ss.str("");
 
-	ss << "@SOFTWARE_DATE:\t\t"     << __DATE__ << " " << __TIME__   << "";
+	ss << "@SOFTWARE_DATE:\t"       << __DATE__ << " " << __TIME__;
 	string sss = ss.str();
 	sss = ss.str();
 	sss.erase(remove(sss.begin(), sss.end(), '\n'), sss.end());
 	midifile.addText(0, 0, sss); ss.str("");
 
 #ifndef DONOTUSEFFT
-	ss << "@ANALYSIS_DATE:\t\t"     << std::ctime(&current_time);
+	ss << "@ANALYSIS_DATE:\t"       << std::ctime(&current_time);
 	sss = ss.str();
 	sss = ss.str();
 	sss.erase(remove(sss.begin(), sss.end(), '\n'), sss.end());
 	midifile.addText(0, 0, sss); ss.str("");
 
-	ss << "@ANALYSIS_TIME:\t\t"     << int(processing_time.count()*100.0+0.5)/100.0 << "sec" << "";
+	ss << "@ANALYSIS_TIME:\t"       << int(processing_time.count()*100.0+0.5)/100.0 << "sec";
 	midifile.addText(0, 0, ss.str()); ss.str("");
 #endif
-	ss << "@COLOR_CHANNEL:\t\t"     << "green"                       << "";
+	ss << "@COLOR_CHANNEL:\t"       << "green";
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@CHANNEL_MD5:\t\t"       << getDataMD5Sum()               << "";
+	ss << "@CHANNEL_MD5:\t"         << getDataMD5Sum();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@BRIDGE_FACTOR:\t\t"     << getBridgeFactor()             << "";
+	ss << "@BRIDGE_FACTOR:\t"       << getBridgeFactor();
 	midifile.addText(0, 0, ss.str()); ss.str("");
-	ss << "@MANUAL_EDITS:\t\t"      << "no "                         << "";
+	ss << "@MANUAL_EDITS:\t"        << "no";
 	midifile.addText(0, 0, ss.str()); ss.str("");
 }
 


### PR DESCRIPTION
This PR needs to be rebased against the master branch after PR #18 is merged.

These changes remove the unit suffixes (e.g., "`px`") from most MIDI track 0 metadata messages as well as from the hole report data generated in the output of `midi2exp`. The former is subsequently extracted and loaded into raw/hole and note MIDI files via the `extractMidiFiles` script.

Unlike some of the other output from `midi2exp`, both the hole report data and the MIDI metadata values are typically parsed by machine and used programmatically, rather than read by humans, so streamlining the data in this way facilitates such use.

The MIDI time division "ticks per quarter" value is also written into the MIDI metadata. This value is of course also present in the MIDI header, but in certain circumstances it is more convenient to obtain it from the metadata track.