### PR TITLE
Add options to parse images of Duo-Art and Ampico A/B rolls

### DIFF
--- a/include/RollOptions.h
+++ b/include/RollOptions.h
@@ -54,6 +54,9 @@ class RollOptions {
 		void     setRollTypeLicenseeWelte     (void);
 		void     setRollType65Note            (void);
 		void     setRollType88Note            (void);
+		void     setRollTypeDuoArt            (void);
+		void     setRollTypeAmpico            (void);
+		void     setRollTypeAmpicoB           (void);
 
 		int      getRewindHoleBassNumber      (void);
 		int      getRewindHoleBassIndex       (void);

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -4386,21 +4386,29 @@ void RollImage::setMidiFileTempo(MidiFile& midifile) {
 		// TPQ is 6 times the tempo at 300 DPI, (so 591 = 6 * 98.5)
 		// 591 is for Red Welte tempo of 98.5 (~3 meters/minute)
 		// 568 is the currently preferred value, however.
+		// Wayne Stahnke uses 47.2 mm/s (1.858 in/s) = 557.4 TPQ
 		midifile.setTPQ(568);
 		setRollAcceleration(.30865);
 	} else if (m_rollType == "welte-green") {
 		// Peter Phillips's dissertation describes the speed for green Welte
-		// rolls as "seven feet per minute" (p. 121). 7ft/min = 2.1336m/min =
+		// rolls as "seven feet per minute" (p. 121). 7 ft/min = 2.1336 m/min =
 		// tempo of 70.0532 (* 6 = 420).
 		midifile.setTPQ(420);
-		setRollAcceleration(.22336);
+		setRollAcceleration(.16896);
+	} else if (m_rollType == "welte-licensee") {
+		// This is equivalent to the median speed of "eight feet per minute"
+		// that Peter Phillips mentions for the De Luxe Welte Licensee rolls 
+		// (p. 126): 8 ft/min = 2.438 m/min = tempo of 80.0608.
+		// Wayne Stahnke suggests a speed of 1.7 in/s = 8.5 ft/min = 510 TPQ
+		midifile.setTPQ(6 * 80);
+		// XXX Acceleration has not been modeled/observed. Wayne Stahnke
+		// projects that the effective spool diameter for Licensee is ~90.9%
+		// of the Green spool, so assuming this translates to acceleration:
+		setRollAcceleration(.16896 * 0.909);
 	} else if (m_rollType == "88-note") {
 		midifile.setTPQ(6 * 60); 
 	} else {
 		// set to a neutral guess tempo of 80 for now if unknown, this can be adjusted later.
-		// Note that this is equivalent to the median speed of "eight feet per
-		// minute" that Peter Phillips mentions for the De Luxe Welte Licensee
-		// rolls (p. 126): 8ft/min = 2.4384m/min = tempo of 80.0608
 		midifile.setTPQ(6 * 80); 
 	}
 }

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -507,7 +507,7 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 //       95: -4:  Treble theme snakebite     MIDI Key 110
 //       96: -3:  Blank                      MIDI Key 111
 //       97: -2:  Blank                      MIDI Key 112
-//       98: -1:  Treble                     MIDI Key 113
+//       98: -1:  Sustain pedal              MIDI Key 113
 //		 
 
 void RollOptions::setRollTypeDuoArt(void) {
@@ -542,65 +542,64 @@ void RollOptions::setRollTypeDuoArt(void) {
 //
 // CAVEAT: These values are highly tentative and experimental.
 //
-// Ampico A tracker holes:
+// Ampico (A) tracker holes:
 //
-//   9 expression/control holes on bass side:
-//       1:  Rewind (wide hole)              MIDI Key 16
-//       2:  Empty (overlaps with rewind)    MIDI Key 17
+//   7 expression holes on the bass side:
+//       1:  Bass                            MIDI Key 16
+//       2:  Bass                            MIDI Key 17
 //       3:  Soft pedal                      MIDI Key 18
-//       4:  Bass theme snakebite            MIDI Key 19
-//       5:  Bass theme snakebite            MIDI Key 20
-//       6:  Bass volume                     MIDI Key 21
-//       7:  Bass volume                     MIDI Key 22
-//       8:  Bass volume                     MIDI Key 23
-//       9:  Bass volume                     MIDI Key 24
-//   Then 80 notes from C#1 to G#7 (MIDI notes 25 to 104)
-//       10: C#1                             MIDI Key 25
+//       4:  Bass                            MIDI Key 19
+//       5:  Bass                            MIDI Key 20
+//       6:  Bass                            MIDI Key 21
+//       7:  Bass                            MIDI Key 22
+//   Then 83 notes from B0 to A7 (MIDI notes 23 to 105)
+//       8:  B0                              MIDI Key 23
 //       ...
-//       48: D#4                             MIDI Key 63
-//    Treble register:
 //       49: E4                              MIDI Key 64
+//    Treble register:
+//       50: F4                              MIDI Key 65
 //       ...
-//       89: G#7                             MIDI Key 104
-//   9 expression holes on the treble side:
-//       90: -9:  Treble volume              MIDI Key 105
-//       91: -8:  Treble volume              MIDI Key 106
-//       92: -7:  Treble volume              MIDI Key 107
-//       93: -6:  Treble volume              MIDI Key 108
-//       94: -5:  Treble theme snakebite     MIDI Key 109
-//       95: -4:  Treble theme snakebite     MIDI Key 110
-//       96: -3:  Blank                      MIDI Key 111
-//       97: -2:  Blank                      MIDI Key 112
+//       90: A7                              MIDI Key 105
+//   8 expression/control holes on the treble side:
+//       91: -8:  Rewind                     MIDI Key 106
+//       92: -7:  Treble                     MIDI Key 107
+//       93: -6:  Treble                     MIDI Key 108
+//       94: -5:  Treble                     MIDI Key 109
+//       95: -4:  Treble                     MIDI Key 110
+//       96: -3:  Sustain pedal              MIDI Key 111
+//       97: -2:  Treble                     MIDI Key 112
 //       98: -1:  Treble                     MIDI Key 113
 //		 
 
 void RollOptions::setRollTypeAmpico(void) {
 	m_rollType = "ampico";
 	m_minTrackerSpacingToPaperEdge = 1.6; // check
-	m_rewindHole = 1;
-	m_rewindHoleMidi = 16;
+	m_rewindHole = 91; // Beware of post-rewind patterns on recut rolls
+	m_rewindHoleMidi = 106;
 	m_trackerHoles = 98;
 
-	m_bass_midi = 25;   // first MIDI Note on bass side of paper
-	m_treble_midi = 64; // first MIDI Note on treble side of paper
+	m_bass_midi = 16;   // first MIDI Note on bass side of paper
+	m_treble_midi = 65; // first MIDI Note on treble side of paper
 
 	m_bassExpressionTrackStartNumberLeft = 1;
 	m_bassExpressionTrackStartMidi = 16;
-	m_bassNotesTrackStartNumberLeft = 10;
-	m_bassNotesTrackStartMidi = 25;
+	m_bassNotesTrackStartNumberLeft = 8;
+	m_bassNotesTrackStartMidi = 23;
 
-	m_trebleNotesTrackStartNumberLeft = 49;
-	m_trebleNotesTrackStartMidi = 64;
+	m_trebleNotesTrackStartNumberLeft = 50;
+	m_trebleNotesTrackStartMidi = 65;
 
-	m_trebleExpressionTrackStartNumberLeft = 90;
-	m_trebleExpressionTrackStartMidi = 105;
+	m_trebleExpressionTrackStartNumberLeft = 91;
+	m_trebleExpressionTrackStartMidi = 106;
 
 	hasExpressionMidiFileSetup();
 }
 
 
+// If tracker positions are the same, there's no need to differentiate between
+// Ampico (A) and B when detecting holes
 void RollOptions::setRollTypeAmpicoB(void) {
-		m_rollType = "ampico-b";
+	setRollTypeAmpico();
 }
 
 

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -475,7 +475,6 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 //
 // RollOptions::setRollTypeDuoArt -- Apply settings suitable for Aeolian Duo-Art piano rolls.
 //
-// CAVEAT: These values are highly tentative and experimental.
 // Note that the snakebite holes are somewhat narrower than the other holes,
 // and the rewind hole is wider.
 //
@@ -541,8 +540,6 @@ void RollOptions::setRollTypeDuoArt(void) {
 //
 // RollOptions::setRollTypeAmpico -- Apply settings suitable for Ampico (A) piano rolls.
 //
-// CAVEAT: These values are highly tentative and experimental.
-//
 // Ampico (A) tracker holes:
 //
 //   7 expression holes on the bass side:
@@ -601,8 +598,6 @@ void RollOptions::setRollTypeAmpico(void) {
 //////////////////////////////
 //
 // RollOptions::setRollTypeAmpicoB -- Apply settings suitable for Ampico (B) piano rolls.
-//
-// CAVEAT: These values are highly tentative and experimental.
 //
 // Ampico (B) tracker holes:
 //

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -470,6 +470,7 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 }
 
 
+
 //////////////////////////////
 //
 // RollOptions::setRollTypeDuoArt -- Apply settings suitable for Aeolian Duo-Art piano rolls.
@@ -480,7 +481,7 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 //
 // Duo-Art tracker holes:
 //
-//   9 expression/control holes on bass side:
+//   9 expression/control columns on bass side (some empty):
 //       1:  Rewind (wide hole)              MIDI Key 16
 //       2:  Empty (overlaps with rewind)    MIDI Key 17
 //       3:  Soft pedal                      MIDI Key 18
@@ -498,7 +499,7 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 //       49: E4                              MIDI Key 64
 //       ...
 //       89: G#7                             MIDI Key 104
-//   9 expression holes on the treble side:
+//   9 expression columns on the treble side (some empty):
 //       90: -9:  Treble volume              MIDI Key 105
 //       91: -8:  Treble volume              MIDI Key 106
 //       92: -7:  Treble volume              MIDI Key 107
@@ -535,7 +536,7 @@ void RollOptions::setRollTypeDuoArt(void) {
 }
 
 
-// Ampico register break at E4/F4
+
 //////////////////////////////
 //
 // RollOptions::setRollTypeAmpico -- Apply settings suitable for Ampico (A) piano rolls.
@@ -596,11 +597,13 @@ void RollOptions::setRollTypeAmpico(void) {
 }
 
 
+
 // If tracker positions are the same, there's no need to differentiate between
 // Ampico (A) and B when detecting holes
 void RollOptions::setRollTypeAmpicoB(void) {
 	setRollTypeAmpico();
 }
+
 
 
 //////////////////////////////

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -487,10 +487,10 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 //       3:  Soft pedal                      MIDI Key 18
 //       4:  Bass theme snakebite            MIDI Key 19
 //       5:  Bass theme snakebite            MIDI Key 20
-//       6:  Bass volume                     MIDI Key 21
-//       7:  Bass volume                     MIDI Key 22
-//       8:  Bass volume                     MIDI Key 23
-//       9:  Bass volume                     MIDI Key 24
+//       6:  Bass volume 1                   MIDI Key 21
+//       7:  Bass volume 2                   MIDI Key 22
+//       8:  Bass volume 4                   MIDI Key 23
+//       9:  Bass volume 8                   MIDI Key 24
 //   Then 80 notes from C#1 to G#7 (MIDI notes 25 to 104)
 //       10: C#1                             MIDI Key 25
 //       ...
@@ -500,15 +500,15 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 //       ...
 //       89: G#7                             MIDI Key 104
 //   9 expression columns on the treble side (some empty):
-//       90: -9:  Treble volume              MIDI Key 105
-//       91: -8:  Treble volume              MIDI Key 106
-//       92: -7:  Treble volume              MIDI Key 107
-//       93: -6:  Treble volume              MIDI Key 108
+//       90: -9:  Treble volume 8            MIDI Key 105
+//       91: -8:  Treble volume 4            MIDI Key 106
+//       92: -7:  Treble volume 2            MIDI Key 107
+//       93: -6:  Treble volume 1            MIDI Key 108
 //       94: -5:  Treble theme snakebite     MIDI Key 109
 //       95: -4:  Treble theme snakebite     MIDI Key 110
 //       96: -3:  Blank                      MIDI Key 111
 //       97: -2:  Blank                      MIDI Key 112
-//       98: -1:  Sustain pedal              MIDI Key 113
+//       98: -1:  Sustain         pedal      MIDI Key 113
 //		 
 
 void RollOptions::setRollTypeDuoArt(void) {
@@ -546,13 +546,13 @@ void RollOptions::setRollTypeDuoArt(void) {
 // Ampico (A) tracker holes:
 //
 //   7 expression holes on the bass side:
-//       1:  Bass                            MIDI Key 16
-//       2:  Bass                            MIDI Key 17
+//       1:  Bass slow cresc                 MIDI Key 16
+//       2:  Bass intensity 2                MIDI Key 17
 //       3:  Soft pedal                      MIDI Key 18
-//       4:  Bass                            MIDI Key 19
-//       5:  Bass                            MIDI Key 20
-//       6:  Bass                            MIDI Key 21
-//       7:  Bass                            MIDI Key 22
+//       4:  Bass intensity 4                MIDI Key 19
+//       5:  Bass fast cresc                 MIDI Key 20
+//       6:  Bass intensity 6                MIDI Key 21
+//       7:  Bass intensity cancel           MIDI Key 22
 //   Then 83 notes from B0 to A7 (MIDI notes 23 to 105)
 //       8:  B0                              MIDI Key 23
 //       ...
@@ -563,13 +563,13 @@ void RollOptions::setRollTypeDuoArt(void) {
 //       90: A7                              MIDI Key 105
 //   8 expression/control holes on the treble side:
 //       91: -8:  Rewind                     MIDI Key 106
-//       92: -7:  Treble                     MIDI Key 107
-//       93: -6:  Treble                     MIDI Key 108
-//       94: -5:  Treble                     MIDI Key 109
-//       95: -4:  Treble                     MIDI Key 110
+//       92: -7:  Treble intensity cancel    MIDI Key 107
+//       93: -6:  Treble intensity 6         MIDI Key 108
+//       94: -5:  Treble fast cresc          MIDI Key 109
+//       95: -4:  Treble intensity 4         MIDI Key 110
 //       96: -3:  Sustain pedal              MIDI Key 111
-//       97: -2:  Treble                     MIDI Key 112
-//       98: -1:  Treble                     MIDI Key 113
+//       97: -2:  Treble intensity 2         MIDI Key 112
+//       98: -1:  Treble slow cresc          MIDI Key 113
 //		 
 
 void RollOptions::setRollTypeAmpico(void) {
@@ -598,10 +598,65 @@ void RollOptions::setRollTypeAmpico(void) {
 
 
 
-// If tracker positions are the same, there's no need to differentiate between
-// Ampico (A) and B when detecting holes
+//////////////////////////////
+//
+// RollOptions::setRollTypeAmpicoB -- Apply settings suitable for Ampico (B) piano rolls.
+//
+// CAVEAT: These values are highly tentative and experimental.
+//
+// Ampico (B) tracker holes:
+//
+//   8 expression holes on the bass side:
+//       1:  Amplifier trigger (B only)      MIDI Key 15
+//       2:  Unused (A only)                 MIDI Key 16
+//       3:  Bass intensity 2                MIDI Key 17
+//       4:  Soft pedal                      MIDI Key 18
+//       5:  Bass intensity 4                MIDI Key 19
+//       6:  Unused (A only)                 MIDI Key 20
+//       7:  Bass intensity 6                MIDI Key 21
+//       8:  Bass intensity cancel           MIDI Key 22
+//   Then 83 notes from B0 to A7 (MIDI notes 23 to 105)
+//       9:  B0                              MIDI Key 23
+//       ...
+//       50: E4                              MIDI Key 64
+//    Treble register:
+//       51: F4                              MIDI Key 65
+//       ...
+//       91: A7                              MIDI Key 105
+//   9 expression/control holes on the treble side:
+//       92: -9:  Rewind                     MIDI Key 106
+//       93: -8:  Treble intensity cancel    MIDI Key 107
+//       94: -7:  Treble intensity 6         MIDI Key 108
+//       95: -6:  Treble fast cresc          MIDI Key 109
+//       96: -5:  Treble intensity 4         MIDI Key 110
+//       97: -4:  Sustain pedal              MIDI Key 111
+//       98: -3:  Treble intensity 2         MIDI Key 112
+//       99: -2:  Treble slow cresc          MIDI Key 113
+//      100: -1:  Sub intensity (B only)     MIDI Key 114
+//
+
 void RollOptions::setRollTypeAmpicoB(void) {
-	setRollTypeAmpico();
+	m_rollType = "ampico_b";
+	m_minTrackerSpacingToPaperEdge = 1.6; // check
+	m_rewindHole = 92; // Beware of post-rewind patterns on recut rolls
+	m_rewindHoleMidi = 106;
+	m_trackerHoles = 100;
+
+	m_bass_midi = 15;   // first MIDI Note on bass side of paper
+	m_treble_midi = 65; // first MIDI Note on treble side of paper
+
+	m_bassExpressionTrackStartNumberLeft = 1;
+	m_bassExpressionTrackStartMidi = 15;
+	m_bassNotesTrackStartNumberLeft = 9;
+	m_bassNotesTrackStartMidi = 23;
+
+	m_trebleNotesTrackStartNumberLeft = 51;
+	m_trebleNotesTrackStartMidi = 65;
+
+	m_trebleExpressionTrackStartNumberLeft = 92;
+	m_trebleExpressionTrackStartMidi = 106;
+
+	hasExpressionMidiFileSetup();
 }
 
 

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -470,9 +470,139 @@ void RollOptions::setRollTypeLicenseeWelte(void) {
 }
 
 
-// Duo-Art register break at D#4/E4
+//////////////////////////////
+//
+// RollOptions::setRollTypeDuoArt -- Apply settings suitable for Aeolian Duo-Art piano rolls.
+//
+// CAVEAT: These values are highly tentative and experimental.
+// Note that the snakebite holes are somewhat narrower than the other holes,
+// and the rewind hole is wider.
+//
+// Duo-Art tracker holes:
+//
+//   9 expression/control holes on bass side:
+//       1:  Rewind (wide hole)              MIDI Key 16
+//       2:  Empty (overlaps with rewind)    MIDI Key 17
+//       3:  Soft pedal                      MIDI Key 18
+//       4:  Bass theme snakebite            MIDI Key 19
+//       5:  Bass theme snakebite            MIDI Key 20
+//       6:  Bass volume                     MIDI Key 21
+//       7:  Bass volume                     MIDI Key 22
+//       8:  Bass volume                     MIDI Key 23
+//       9:  Bass volume                     MIDI Key 24
+//   Then 80 notes from C#1 to G#7 (MIDI notes 25 to 104)
+//       10: C#1                             MIDI Key 25
+//       ...
+//       48: D#4                             MIDI Key 63
+//    Treble register:
+//       49: E4                              MIDI Key 64
+//       ...
+//       89: G#7                             MIDI Key 104
+//   9 expression holes on the treble side:
+//       90: -9:  Treble volume              MIDI Key 105
+//       91: -8:  Treble volume              MIDI Key 106
+//       92: -7:  Treble volume              MIDI Key 107
+//       93: -6:  Treble volume              MIDI Key 108
+//       94: -5:  Treble theme snakebite     MIDI Key 109
+//       95: -4:  Treble theme snakebite     MIDI Key 110
+//       96: -3:  Blank                      MIDI Key 111
+//       97: -2:  Blank                      MIDI Key 112
+//       98: -1:  Treble                     MIDI Key 113
+//		 
+
+void RollOptions::setRollTypeDuoArt(void) {
+	m_rollType = "duo-art";
+	m_minTrackerSpacingToPaperEdge = 1.6; // check
+	m_rewindHole = 1;
+	m_rewindHoleMidi = 16;
+	m_trackerHoles = 98;
+
+	m_bass_midi = 16;   // first MIDI Note on bass side of paper
+	m_treble_midi = 64; // first MIDI Note on treble side of paper
+
+	m_bassExpressionTrackStartNumberLeft = 1;
+	m_bassExpressionTrackStartMidi = 16;
+	m_bassNotesTrackStartNumberLeft = 10;
+	m_bassNotesTrackStartMidi = 25;
+
+	m_trebleNotesTrackStartNumberLeft = 49;
+	m_trebleNotesTrackStartMidi = 64;
+
+	m_trebleExpressionTrackStartNumberLeft = 90;
+	m_trebleExpressionTrackStartMidi = 105;
+
+	hasExpressionMidiFileSetup();
+}
+
 
 // Ampico register break at E4/F4
+//////////////////////////////
+//
+// RollOptions::setRollTypeAmpico -- Apply settings suitable for Ampico (A) piano rolls.
+//
+// CAVEAT: These values are highly tentative and experimental.
+//
+// Ampico A tracker holes:
+//
+//   9 expression/control holes on bass side:
+//       1:  Rewind (wide hole)              MIDI Key 16
+//       2:  Empty (overlaps with rewind)    MIDI Key 17
+//       3:  Soft pedal                      MIDI Key 18
+//       4:  Bass theme snakebite            MIDI Key 19
+//       5:  Bass theme snakebite            MIDI Key 20
+//       6:  Bass volume                     MIDI Key 21
+//       7:  Bass volume                     MIDI Key 22
+//       8:  Bass volume                     MIDI Key 23
+//       9:  Bass volume                     MIDI Key 24
+//   Then 80 notes from C#1 to G#7 (MIDI notes 25 to 104)
+//       10: C#1                             MIDI Key 25
+//       ...
+//       48: D#4                             MIDI Key 63
+//    Treble register:
+//       49: E4                              MIDI Key 64
+//       ...
+//       89: G#7                             MIDI Key 104
+//   9 expression holes on the treble side:
+//       90: -9:  Treble volume              MIDI Key 105
+//       91: -8:  Treble volume              MIDI Key 106
+//       92: -7:  Treble volume              MIDI Key 107
+//       93: -6:  Treble volume              MIDI Key 108
+//       94: -5:  Treble theme snakebite     MIDI Key 109
+//       95: -4:  Treble theme snakebite     MIDI Key 110
+//       96: -3:  Blank                      MIDI Key 111
+//       97: -2:  Blank                      MIDI Key 112
+//       98: -1:  Treble                     MIDI Key 113
+//		 
+
+void RollOptions::setRollTypeAmpico(void) {
+	m_rollType = "ampico";
+	m_minTrackerSpacingToPaperEdge = 1.6; // check
+	m_rewindHole = 1;
+	m_rewindHoleMidi = 16;
+	m_trackerHoles = 98;
+
+	m_bass_midi = 25;   // first MIDI Note on bass side of paper
+	m_treble_midi = 64; // first MIDI Note on treble side of paper
+
+	m_bassExpressionTrackStartNumberLeft = 1;
+	m_bassExpressionTrackStartMidi = 16;
+	m_bassNotesTrackStartNumberLeft = 10;
+	m_bassNotesTrackStartMidi = 25;
+
+	m_trebleNotesTrackStartNumberLeft = 49;
+	m_trebleNotesTrackStartMidi = 64;
+
+	m_trebleExpressionTrackStartNumberLeft = 90;
+	m_trebleExpressionTrackStartMidi = 105;
+
+	hasExpressionMidiFileSetup();
+}
+
+
+void RollOptions::setRollTypeAmpicoB(void) {
+		m_rollType = "ampico-b";
+}
+
 
 //////////////////////////////
 //

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -37,9 +37,9 @@ int main(int argc, char** argv) {
 	options.define("r|red|red-welte|welte-red=b", "Assume Red-Welte (T-100) piano roll");
 	options.define("g|green|green-welte|welte-green=b", "Assume Green-Welte (T-98) piano roll");
 	options.define("l|licensee|licensee-welte|welte-licensee=b", "Assume Licensee piano roll");
-	options.define("a|ampico=b", "Assume Ampico [A] piano roll (option not active yet)");
-	options.define("b|ampico-b=b", "Assume Ampico B piano roll (option not active yet)");
-	options.define("d|duo-art=b", "Assume Aeolean Duo-Art piano roll (option not active yet)");
+	options.define("a|ampico=b", "Assume Ampico [A] piano roll (EXPERIMENTAL)");
+	options.define("b|ampico-b=b", "Assume Ampico B piano roll (EXPERIMENTAL)");
+	options.define("d|duo-art=b", "Assume Aeolean Duo-Art piano roll (EXPERIMENTAL)");
 	options.define("5|65|65-note|65-hole=b", "Assume 65-note roll");
 	options.define("8|88|88-note|88-hole=b", "Assume 88-note roll");
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -72,6 +72,12 @@ int main(int argc, char** argv) {
 		roll.setRollType65Note();
 	} else if (options.getBoolean("88-note")) {
 		roll.setRollType88Note();
+	} else if (options.getBoolean("ampico")) {
+		roll.setRollTypeAmpico();
+	} else if (options.getBoolean("ampico-b")) {
+		roll.setRollTypeAmpicoB();
+	} else if (options.getBoolean("duo-art")) {
+		roll.setRollTypeDuoArt();
 	} else {
 		cerr << "A Roll type is required:" << endl;
 		cerr << "   -r   == for red Welte rolls"   << endl;
@@ -79,6 +85,9 @@ int main(int argc, char** argv) {
 		cerr << "   -l   == for Licensee Welte rolls" << endl;
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
+		cerr << "   -a   == for Ampico [A] rolls"  << endl;
+		cerr << "   -b   == for Ampico B rolls"    << endl;
+		cerr << "   -d   == for Duo-Art rolls"     << endl;
 		exit(1);
 	}
 


### PR DESCRIPTION
The tracker hole and MIDI number assignments for the new roll types have been double-checked against other sources on roll layouts and found to work in small-scale image parsing tests, so we might as well go ahead and enable the options.

There's also a commit that modifies some default tempos and acceleration rates for the Welte roll types. These have been updated from the results of ongoing experiments, and likely will be updated again in the future, but it's worth using the most recent numbers.