### PR TITLE
Allow adjustment of tracker alignment by command line

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -142,6 +142,7 @@ class RollImage : public TiffFile, public RollOptions {
 		void            generateNoteMidiFileBinasc    (ostream& output);
 		void            generateHoleMidiFileHex       (ostream& output);
 		void            generateHoleMidiFileBinasc    (ostream& output);
+		void			setAlignmentShift			  (int trackerShift);
 
 #ifndef DONOTUSEFFT
 		void            generateMidifile              (MidiFile& midifile);
@@ -345,6 +346,11 @@ class RollImage : public TiffFile, public RollOptions {
 		bool       m_isMonochrome;
 		bool       m_useRewindHoleCorrection;
 		bool       m_emulateAcceleration;
+		// m_trackerMapShift -- the leftmost potential tracker bar column
+		// considered to be a legitimate hole column for the roll type is
+		// calculated by analyzeMidiKeyMapping() but can be modified via this
+		// value, which is set from the command line.
+		int        m_trackerMapShift = 0;
 
 #ifndef DONOTUSEFFT
 		std::chrono::system_clock::time_point start_time;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -152,6 +152,16 @@ void RollImage::toggleAccelerationEmulation(bool value) {
 
 //////////////////////////////
 //
+// RollImage::setAlignmentShift 
+//
+void RollImage::setAlignmentShift(int value) {
+	m_trackerMapShift = value;
+}
+
+
+
+//////////////////////////////
+//
 // RollImage::loadGreenChannel -- Load the green channel of the input image
 //   and trim at the brightness threshold for the paper/hole boundary.
 //
@@ -918,7 +928,12 @@ void RollImage::analyzeMidiKeyMapping(void) {
 	}
 
 	leftmostIndex = bestLeftIndex;
+
 	std::cerr << "After considering alternatives, leftmostIndex is now " << leftmostIndex << std::endl;	
+	if (m_trackerMapShift != 0) {
+		leftmostIndex += m_trackerMapShift;
+		std::cerr << "Applying specified shift of " << m_trackerMapShift << ", leftmostIndex is now " << leftmostIndex << std::endl;	
+	}
 
 	// Initialize the MIDI-to-track mapping:
 	midiToTrackMapping.resize(128);

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
 	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
 	options.define("s|disregard-rewind-hole=b", "Skip rewind hole correction for tracker->MIDI mapping");
 	options.define("e|emulate-roll-acceleration=b", "Add tempo events to note MIDI for acceleration");
-	options.define("a|alignment-shift=i:0", "Shift leftmost valid position for tracker->MIDI mapping");
+	options.define("i|alignment-shift=i:0", "Shift leftmost valid position for tracker->MIDI mapping");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv) {
 	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
 	options.define("s|disregard-rewind-hole=b", "Skip rewind hole correction for tracker->MIDI mapping");
 	options.define("e|emulate-roll-acceleration=b", "Add tempo events to note MIDI for acceleration");
+	options.define("a|alignment-shift=i:0", "Shift leftmost valid position for tracker->MIDI mapping");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 1) {
@@ -92,10 +93,13 @@ int main(int argc, char** argv) {
 
 	int threshold = options.getInteger("threshold");
 
+	int trackerShift = options.getInteger("alignment-shift");
+
 	roll.setDebugOn();
 	roll.setWarningOn();
 	roll.setMonochrome(options.getBoolean("monochrome"));
 	roll.loadGreenChannel(threshold);
+	roll.setAlignmentShift(trackerShift);
 	roll.analyze();
 	roll.printRollImageProperties();
 


### PR DESCRIPTION
Despite all of the countermeasures now in place, there's still one known case of a roll for which the tracker columns on the roll receive MIDI numbers that are shifted from their correct assignments: https://pianolatron.stanford.edu/?druid=zk199jz1564, which currently is shifted one column too far to the right (so the sustain pedal perforations, which should be MIDI 18, are assigned MIDI 17 -- a noop position). This seems to occur because 1) it's an 88-note roll, so there's no rewind hole to aid in alignment, and the possible extent of the marginal holes an 88-note roll may use is much wider than the range they typically employ, and 2) the truncated treble range of the piece doesn't provide sufficient columns for the alignment logic to "fit" the columns to MIDI numbers (it never goes above E5 and doesn't use snakebite accents, leaving the top two and a half octaves of the keyboard and the rightmost quarter of the roll paper unused).

Rather than chase down these increasingly rare corner cases, it's a better use of developer time simply to add a command-line option to shift the column assignments to the left or to the right of the position they'd otherwise be assigned. These corrections can be added to an exceptions list that is applied each time the entire roll image corpus is re-processed.