### PR TITLE
Search smoothed histogram of inter-perforation distances to find note continuation threshold

### DIFF
--- a/include/HoleInfo.h
+++ b/include/HoleInfo.h
@@ -39,7 +39,7 @@ class HoleInfo {
 		         HoleInfo     (void);
 		        ~HoleInfo     ();
 
-		std::pair<ulongint, ulongint> origin;   // Row, Column of origin (top let corner)
+		std::pair<ulongint, ulongint> origin;   // Row, Column of origin (top left corner)
 		std::pair<ulongint, ulongint> width;    // Row, Column widths.
 		std::pair<double, double>     centroid; // Center of mass
 		std::pair<ulongint, ulongint> entry;    // entry point for filling holes

--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -291,6 +291,7 @@ class RollImage : public TiffFile, public RollOptions {
 		void       addDriftInfoToHoles         (void);
 		void       groupHoles                  (void);
 		void       groupHoles                  (ulongint index);
+		void       getInterHoleCutoff          (void);
 		void       describeTears               (void);
 		ulongint   processTearLeft             (ulongint startrow, ulongint startcol);
 		ulongint   processTearRight            (ulongint startrow, ulongint startcol);
@@ -342,6 +343,7 @@ class RollImage : public TiffFile, public RollOptions {
 		double     m_dustscorebass;
 		double     m_dustscoretreble;
 		double     m_averageHoleWidth;
+		double     m_interHoleCutoff;
 		bool       m_isMonochrome;
 		bool       m_useRewindHoleCorrection;
 		bool       m_emulateAcceleration;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -401,10 +401,10 @@ return; // disabling for now
 // RollImage::getInterHoleCutoff -- Build a histogram of the distances in
 //   pixels between the end of each perforation and the start of the next in
 //   each tracker column. Smooth the histogram, then choose the distance with
-//   the smallest number items in its histogram bin that is within the average
+//   the smallest number of items in its histogram bin that is within the average
 //   perforation width for the roll +/- (searchlen * the avg perforation width)
 //   and assign this value (in pixels) to m_interHoleCutoff. The value can
-//   then be used in RollImage::groupHoles() to merge continutation holes
+//   then be used in RollImage::groupHoles() to merge continuation holes
 //   (which are recorded individually in the raw MIDI output) into continuous
 //   note events in the note MIDI output.
 //
@@ -420,7 +420,7 @@ void RollImage::getInterHoleCutoff(void) {
 
 	double avglen = getAverageMusicalHoleWidth();
 
-    // Build the inter-perforation distance histogram
+	// Build the inter-perforation distance histogram
 	for (ulongint trackerIndex=0; trackerIndex<trackerArray.size(); trackerIndex++) {
 		vector<HoleInfo*>& hi = trackerArray[trackerIndex];
 
@@ -447,7 +447,7 @@ void RollImage::getInterHoleCutoff(void) {
 	double smallestValInWindow = -1;
 	double smallestBinInWindow = int(avglen);
 
-    // Smooth the histogram and keep track of the best candidate for the inter-
+	// Smooth the histogram and keep track of the best candidate for the inter-
 	// hole distance seen so far
 	for (int i=0; i<(int)histogram.size(); i++) {
 		if ((i - winlen >= 0) && (i + winlen < (int)histogram.size())) {
@@ -499,8 +499,8 @@ void RollImage::groupHoles(void) {
 
 void RollImage::groupHoles(ulongint index) {
 	vector<HoleInfo*>& hi = trackerArray[index];
-	//double scalefactor = getBridgeFactor(); // This doesn't work very well
-	//double length = getAverageMusicalHoleWidth() * scalefactor;
+	// double scalefactor = getBridgeFactor(); // This doesn't work very well
+	// double length = getAverageMusicalHoleWidth() * scalefactor;
 	if (hi.empty()) {
 		return;
 	}


### PR DESCRIPTION
The current method for determining whether a vertical gap between two perforations is meant to indicate two separate note strikes or a continuation of a single note involves multiplying an arbitrary "bridge factor" by the average width of a perforation on the roll (in pixels) and using the resulting value as the cutoff threshold. The extra "bridge factor" was introduced to avoid cases in which ragged edges and "hanging chads" in the perforations cause the effective length of a hole to appear shorter than its actual effective pneumatic length. When this happens with holes that are part of a continuation, erroneous restrikes can result. A survey of the roll corpus, however, found that this method causes many more erroneous continuations than the number of restrikes it was meant to fix. See illustration below; an incomplete listing of the rolls with noticeable continuation errors includes mx460bt7026 (very first notes), gq898yv9510, yn137rt9938, hm523dq5554, gh208gz5033, and wt621xq0875.
![Screen Shot 2022-01-10 at 9 33 56 PM](https://user-images.githubusercontent.com/7329112/148888008-8491bcb0-e851-424d-9abd-a9bd7d5b1eec.png)

The new code here incorporates research by @Kizjkre and gap histogram smoothing code from [holegap.cpp](https://github.com/pianoroll/midiroll/blob/master/tools/holegap.cpp). As the comments indicate, it creates a smoothed histogram of the inter-hole distances on the roll, then finds the smallest bin within a certain range of the average hole diameter for the roll; this tends to correspond to the minimum of the "dip" to the right of the large spike centered upon the most common distance between continuation holes on the roll. The latter also tends to be the most common inter-hole distance on the roll, but even when it is not, the "spike" and the "dip" are always the maximum and minimum values within the search range, which defaults to +/- (.5 * avg hole diameter) around the average hole diameter for the roll.
![ch984dr4932_check](https://user-images.githubusercontent.com/7329112/148888773-5b661fb0-1f30-4351-a959-1d95083639fb.png)

There are some indications that this search range may need to be widened for reproducing rolls such as green Welte rolls that play at lower speeds and thus can feature very short inter-hole distances when the recording involves very rapid repeated notes (the artificially constructed 88-note rolls, on the other hand, are usually engineered so that these corner cases simply do not arise). But the current code has been tested and found to work for all formerly problematic rolls and a great many other rolls in the 88-note and red Welte collections.



