### PR TITLE
Accommodate roll images that lack roll leader and pre-leader sections

### DIFF
--- a/include/RollImage.h
+++ b/include/RollImage.h
@@ -91,6 +91,7 @@ class RollImage : public TiffFile, public RollOptions {
 		void	          setMonochrome                 (bool value);
 		void            setRewindCorrection           (bool value);
 		void            toggleAccelerationEmulation   (bool value);
+		void            setMissingLeaders             (bool value);
 		void            analyze                       (void);
 		void            analyzeHoles                  (void);
 		void            mergePixelOverlay             (std::fstream& output);
@@ -353,6 +354,7 @@ class RollImage : public TiffFile, public RollOptions {
 		// calculated by analyzeMidiKeyMapping() but can be modified via this
 		// value, which is set from the command line.
 		int        m_trackerMapShift = 0;
+		bool       m_leadersAreMissing;
 
 #ifndef DONOTUSEFFT
 		std::chrono::system_clock::time_point start_time;

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -67,6 +67,7 @@ void RollImage::clear(void) {
 	m_isMonochrome              = false;
 	m_useRewindHoleCorrection   = true;
 	m_emulateAcceleration       = false;
+	m_leadersAreMissing         = false;
 }
 
 
@@ -156,6 +157,16 @@ void RollImage::toggleAccelerationEmulation(bool value) {
 //
 void RollImage::setAlignmentShift(int value) {
 	m_trackerMapShift = value;
+}
+
+
+
+//////////////////////////////
+//
+// RollImage::setMissingLeaders
+//
+void RollImage::setMissingLeaders(bool value) {
+	m_leadersAreMissing = value;
 }
 
 
@@ -2900,8 +2911,8 @@ void RollImage::analyzeLeaders(void) {
 		// eventually, perhaps reverse processing.
 		std::cerr << "Cannot deal with bottom leader" << std::endl;
 		exit(1);
-	} else {
-		std::cerr << "Cannot find leader (deal with partial rolls later)." << std::endl;
+	} else if (!m_leadersAreMissing) {
+		std::cerr << "Cannot find leader (try -n option)." << std::endl;
 		std::cerr << "TOP LEFT SHOULD BE GREATER THAN BOTTOM LEFT:" << std::endl;
 		std::cerr << "   TOP    LEFT  AVERAGE " << topLeftAvg << std::endl;
 		std::cerr << "   BOTTOM LEFT  AVERAGE " << botLeftAvg << std::endl;
@@ -2912,17 +2923,21 @@ void RollImage::analyzeLeaders(void) {
 	}
 
 	ulongint leftLeaderBoundary = 0;
-	leftLeaderBoundary = findLeftLeaderBoundary(leftMarginIndex, botLeftAvg, cols, 4096*4);
-
 	ulongint rightLeaderBoundary = 0;
-	rightLeaderBoundary = findRightLeaderBoundary(rightMarginIndex, botRightAvg, cols, 4096*4);
+	ulongint leaderBoundary = 0;
+	ulongint preleaderIndex = 0;
 
-	ulongint leaderBoundary = (leftLeaderBoundary + rightLeaderBoundary) / 2;
+	if (!m_leadersAreMissing) {
+		leftLeaderBoundary = findLeftLeaderBoundary(leftMarginIndex, botLeftAvg, cols, 4096*4);
+		rightLeaderBoundary = findRightLeaderBoundary(rightMarginIndex, botRightAvg, cols, 4096*4);
+		leaderBoundary = (leftLeaderBoundary + rightLeaderBoundary) / 2;
+		preleaderIndex = extractPreleaderIndex(leaderBoundary);
+	}
+
 	setLeaderIndex(leaderBoundary);
 	markLeaderRegion();
-
 	// find pre-leader region
-	setPreleaderIndex(extractPreleaderIndex(leaderBoundary));
+	setPreleaderIndex(preleaderIndex);
 	markPreleaderRegion();
 
 	m_analyzedLeaders = true;

--- a/tools/markholes.cpp
+++ b/tools/markholes.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv) {
 	options.define("5|65|65-note|65-hole=b", "Assume 65-note roll");
 	options.define("8|88|88-note|88-hole=b", "Assume 88-note roll");
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");
+	options.define("n|no-leaders=b", "Roll image has no tapered leader/preleader sections before holes");
 	options.process(argc, argv);
 
 	if (options.getArgCount() != 2) {
@@ -79,6 +80,10 @@ int main(int argc, char** argv) {
 		cerr << "   --65 == for 65-note rolls"     << endl;
 		cerr << "   --88 == for 88-note rolls"     << endl;
 		exit(1);
+	}
+
+	if (options.getBoolean("no-leaders")) {
+		roll.setMissingLeaders(true);
 	}
 
 	fstream output;

--- a/tools/tiff2holes.cpp
+++ b/tools/tiff2holes.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv) {
 	options.define("t|threshold=i:249", "Brightness threshold for hole/paper separation");
 	options.define("m|monochrome=b", "Input image is a monochrome (single-channel) TIFF");
 	options.define("s|disregard-rewind-hole=b", "Skip rewind hole correction for tracker->MIDI mapping");
+	options.define("n|no-leaders=b", "Roll image has no tapered leader/preleader sections before holes");
 	options.define("e|emulate-roll-acceleration=b", "Add tempo events to note MIDI for acceleration");
 	options.define("i|alignment-shift=i:0", "Shift leftmost valid position for tracker->MIDI mapping");
 	options.process(argc, argv);
@@ -98,6 +99,10 @@ int main(int argc, char** argv) {
 
 	if (options.getBoolean("emulate-roll-acceleration")) {
 		roll.toggleAccelerationEmulation(true);
+	}
+
+	if (options.getBoolean("no-leaders")) {
+		roll.setMissingLeaders(true);
 	}
 
 	int threshold = options.getInteger("threshold");


### PR DESCRIPTION
These changes are meant to accommodate roll scans that do not include the tapering leader portions that precede the holes and typically include some kind of label and the rollup string attachment. Such scans are only found in collections other than the SUL collections, but in any case, adding this command-line switch should not have any negative effect on the software's ability to process the core collection.

What a leader-less roll image looks like:
![Screen Shot 2022-02-02 at 7 15 48 PM](https://user-images.githubusercontent.com/7329112/152275624-c294e6b4-d10f-4615-ad5c-b23dd78ff64b.png)