### PR TITLE
Use bridge factor for 88-note/65-note continuations

### DIFF
--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -441,6 +441,13 @@ void RollImage::getInterHoleCutoff(void) {
 
 	double avglen = getAverageMusicalHoleWidth();
 
+	// The artificially constructed matrix for 88-note rolls seems to ensure
+	// that the intra-continuation distance is always < the avg hole diameter
+	if (m_rollType == "88-note") {
+		m_interHoleCutoff = avglen;
+		return;
+	}
+
 	// Build the inter-perforation distance histogram
 	for (ulongint trackerIndex=0; trackerIndex<trackerArray.size(); trackerIndex++) {
 		vector<HoleInfo*>& hi = trackerArray[trackerIndex];

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -531,9 +531,9 @@ void RollImage::groupHoles(ulongint index) {
 	// simply the average hole width multiplied by an arbitrary scale factor
 	// works better for some roll types than the cutoff calculated by observing
 	// the smoothed inter-hole distances for the roll -- specifically for
-	// 88-note rolls, which are constructed artificially and are likely to have
-	// a more predictable hole matrix spacing.
-	if (m_rollType == "88-note") {
+	// 88-note rolls and 65-note rolls, which are constructed artificially and
+	// should have more predictable punch matrix spacings.
+	if ((m_rollType == "88-note") || (m_rollType == "65-note")) {
 	    length = getAverageMusicalHoleWidth() * getBridgeFactor();
 	}
 

--- a/src/RollImage.cpp
+++ b/src/RollImage.cpp
@@ -441,13 +441,6 @@ void RollImage::getInterHoleCutoff(void) {
 
 	double avglen = getAverageMusicalHoleWidth();
 
-	// The artificially constructed matrix for 88-note rolls seems to ensure
-	// that the intra-continuation distance is always < the avg hole diameter
-	if (m_rollType == "88-note") {
-		m_interHoleCutoff = avglen;
-		return;
-	}
-
 	// Build the inter-perforation distance histogram
 	for (ulongint trackerIndex=0; trackerIndex<trackerArray.size(); trackerIndex++) {
 		vector<HoleInfo*>& hi = trackerArray[trackerIndex];
@@ -527,10 +520,21 @@ void RollImage::groupHoles(void) {
 
 void RollImage::groupHoles(ulongint index) {
 	vector<HoleInfo*>& hi = trackerArray[index];
-	// double scalefactor = getBridgeFactor(); // This doesn't work very well
-	// double length = getAverageMusicalHoleWidth() * scalefactor;
+	
 	if (hi.empty()) {
 		return;
+	}
+	
+	double length = m_interHoleCutoff;
+
+	// The older approach of using an inter-perforation cutoff distance that is
+	// simply the average hole width multiplied by an arbitrary scale factor
+	// works better for some roll types than the cutoff calculated by observing
+	// the smoothed inter-hole distances for the roll -- specifically for
+	// 88-note rolls, which are constructed artificially and are likely to have
+	// a more predictable hole matrix spacing.
+	if (m_rollType == "88-note") {
+	    length = getAverageMusicalHoleWidth() * getBridgeFactor();
 	}
 
 	HoleInfo* lastattack = NULL;
@@ -539,7 +543,7 @@ void RollImage::groupHoles(ulongint index) {
 	lastattack = hi[0];
 	for (ulongint i=1; i<hi.size(); i++) {
 		hi[i]->prevOff = hi[i]->origin.first - (hi[i-1]->origin.first + hi[i-1]->width.first);
-		if (hi[i]->prevOff <= m_interHoleCutoff) {
+		if (hi[i]->prevOff <= length) {
 			hi[i]->attack = false;
 			if (lastattack) {
 				// extend off time of previous attack

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -697,7 +697,13 @@ void RollOptions::setRollType65Note(void) {
 	m_trebleExpressionTrackStartNumberLeft = 0;
 	m_trebleExpressionTrackStartMidi = 0;
 
-	hasNoExpressionMidiFileSetup();
+        // Including expression tracks for 65-note rolls fits better with the
+        // Pianolatron workflow, which requires that an expressive MIDI file
+        // be generated for each roll, even if it has no expression holes.
+        // This produces slightly odd-looking note and expressive MIDI files
+        // for 65-note rolls, but does no actual harm.
+	//hasNoExpressionMidiFileSetup();
+	hasExpressionMidiFileSetup();
 }
 
 

--- a/src/RollOptions.cpp
+++ b/src/RollOptions.cpp
@@ -422,8 +422,8 @@ void RollOptions::setRollTypeGreenWelte(void) {
 //       4:  Bass Crescendo on               MIDI Key 19
 //       5:  Bass Sforzando off              MIDI Key 20
 //       6:  Bass Sforzando on               MIDI Key 21
-//       7:  Soft pedal on                   MIDI Key 22
-//       8:  Soft pedal off                  MIDI Key 23
+//       7:  Soft pedal off                  MIDI Key 22
+//       8:  Soft pedal on                   MIDI Key 23
 //   Then 80 notes from C1 to G7 (MIDI notes 24 to 103)
 //       9:  C1                              MIDI Key 24
 //       ...
@@ -697,13 +697,7 @@ void RollOptions::setRollType65Note(void) {
 	m_trebleExpressionTrackStartNumberLeft = 0;
 	m_trebleExpressionTrackStartMidi = 0;
 
-        // Including expression tracks for 65-note rolls fits better with the
-        // Pianolatron workflow, which requires that an expressive MIDI file
-        // be generated for each roll, even if it has no expression holes.
-        // This produces slightly odd-looking note and expressive MIDI files
-        // for 65-note rolls, but does no actual harm.
-	//hasNoExpressionMidiFileSetup();
-	hasExpressionMidiFileSetup();
+	hasNoExpressionMidiFileSetup();
 }
 
 


### PR DESCRIPTION
The statistics-based approach to determining the inter-perforation cutoff threshold for note continuations from https://github.com/sul-cidr/roll-image-parser/pull/23 works best with reproducing roll types (especially red Welte) that may not have a consistent inter-perforation distance for note continuations between rolls and roll printing runs.

Artificially constructed pianola rolls, specifically 88-note and 65-note rolls, tend to have a much more consistent inter-perforation cutoff distance, which can be determined for a given roll by multiplying the "bridge factor" specific to the roll type by the observed average hole width for the roll.

There are very few cases for which the difference between these approaches is apparent, but https://pianolatron.stanford.edu/?druid=xz373zg4809 is one such case, and the result from the bridge factor approach is noticeably preferable, especially around 5% of the way through the roll. So we'll use this approach for all 88-note and 65-note rolls, unless counter-examples are found.